### PR TITLE
feature: Add simple query string

### DIFF
--- a/es/simple_query_string.go
+++ b/es/simple_query_string.go
@@ -1,0 +1,306 @@
+package es
+
+type simpleQueryStringType Object
+
+// SimpleQueryString creates a new simpleQueryStringType object with the specified query string.
+//
+// This function initializes a simpleQueryStringType object with a simple query string, which
+// is typically used to perform simple text search queries in Elasticsearch. The query string
+// can contain multiple terms and operators, allowing for basic search expressions.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo + Bar")
+//	// q now contains a simpleQueryStringType object with a simple query string query.
+//
+// Parameters:
+//   - query: The query string to be used in the search. The type is generic and can be
+//     any type that represents a query string.
+//
+// Returns:
+//
+//	A simpleQueryStringType object containing the specified query string.
+func SimpleQueryString[T any](query T) simpleQueryStringType {
+	return simpleQueryStringType{
+		"simple_query_string": Object{
+			"query": query,
+		},
+	}
+}
+
+// Fields sets the fields to be searched within the simpleQueryStringType object.
+//
+// This method specifies a list of fields that the query string should search.
+// If multiple fields are provided, the query will search across all of them,
+// allowing for more flexible and comprehensive search queries.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo Bar").Fields([]string{"title", "content"})
+//	// q now searches within the "title" and "content" fields.
+//
+// Parameters:
+//   - value: A slice of strings representing the field names to be searched.
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "fields" option set.
+func (q simpleQueryStringType) Fields(value []string) simpleQueryStringType {
+	q.putInTheField("fields", value)
+	return q
+}
+
+// Analyzer sets the analyzer to be used for the simpleQueryStringType object.
+//
+// This method specifies the analyzer that should be applied to the query string.
+// Analyzers are used to process the text, such as tokenizing and normalizing it,
+// allowing for more refined and accurate search queries based on the specified analyzer.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo Bar").Analyzer("standard")
+//	// q now uses the "standard" analyzer for processing the query string.
+//
+// Parameters:
+//   - value: A string representing the name of the analyzer to be used.
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "analyzer" set.
+func (q simpleQueryStringType) Analyzer(value string) simpleQueryStringType {
+	q.putInTheField("analyzer", value)
+	return q
+}
+
+// DefaultOperator sets the default operator for the simpleQueryStringType object.
+//
+// This method specifies the default operator to be used between terms in the query string
+// when no explicit operator is provided. The default operator can be "AND" or "OR",
+// determining whether all terms (AND) or any term (OR) must be matched in the search results.
+//
+// Example usage:
+//
+//	q := es.SimpleQueryString("Foo Bar").
+//	DefaultOperator("OR")
+//
+// q now uses "OR" as the default operator, meaning any term can match in the query.
+//
+// Parameters:
+//   - value: A string representing the default operator to be used ("AND" or "OR").
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "default_operator" set.
+func (q simpleQueryStringType) DefaultOperator(value string) simpleQueryStringType {
+	q.putInTheField("default_operator", value)
+	return q
+}
+
+// MinimumShouldMatch sets the minimum number of clauses that must match for the simpleQueryStringType object.
+//
+// This method specifies the minimum number of clauses that must match in order
+// for a document to be considered a match. This can be expressed as an absolute number or a percentage,
+// allowing for fine-tuned control over query matching behavior.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo Bar Baz").MinimumShouldMatch("2")
+//	// q now requires that at least 2 of the terms match for a document to be considered a match.
+//
+// Parameters:
+//   - value: A string representing the minimum number or percentage of clauses that must match.
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "minimum_should_match" option set.
+func (q simpleQueryStringType) MinimumShouldMatch(value string) simpleQueryStringType {
+	q.putInTheField("minimum_should_match", value)
+	return q
+}
+
+// FuzzyMaxExpansions sets the maximum number of expansions for fuzzy matching in the simpleQueryStringType object.
+//
+// This method specifies the maximum number of terms that the query will expand to
+// when performing fuzzy matching. This setting controls the number of variations
+// of the search term that will be considered in the query, affecting both performance
+// and accuracy of fuzzy searches.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo~").FuzzyMaxExpansions(50)
+//	// q now allows up to 50 expansions for fuzzy matching.
+//
+// Parameters:
+//   - value: An integer representing the maximum number of term expansions for fuzzy matching.
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "fuzzy_max_expansions" option set.
+func (q simpleQueryStringType) FuzzyMaxExpansions(value int64) simpleQueryStringType {
+	q.putInTheField("fuzzy_max_expansions", value)
+	return q
+}
+
+// FuzzyPrefixLength sets the prefix length for fuzzy matching in the simpleQueryStringType object.
+//
+// This method specifies the length of the initial characters that must match exactly
+// before applying any fuzziness in the query. Increasing the prefix length can improve
+// performance by reducing the number of potential matches, while still allowing for
+// approximate matching beyond the prefix.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo~").FuzzyPrefixLength(2)
+//	// q now requires the first 2 characters to match exactly before applying fuzziness.
+//
+// Parameters:
+//   - value: An integer representing the number of initial characters that must match exactly.
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "fuzzy_prefix_length" option set.
+func (q simpleQueryStringType) FuzzyPrefixLength(value int64) simpleQueryStringType {
+	q.putInTheField("fuzzy_prefix_length", value)
+	return q
+}
+
+// FuzzyTranspositions sets the option to allow transpositions in fuzzy matching for the simpleQueryStringType object.
+//
+// This method enables or disables the allowance of transpositions (swapping of adjacent characters)
+// in fuzzy matching. When set to true, terms that are similar but have transposed characters
+// (e.g., "ab" vs. "ba") will still be considered a match, increasing the flexibility of the search.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo~").FuzzyTranspositions(true)
+//	// q now allows transpositions in fuzzy matching.
+//
+// Parameters:
+//   - value: A boolean indicating whether transpositions are allowed (true) or not (false).
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "fuzzy_transpositions" option set.
+func (q simpleQueryStringType) FuzzyTranspositions(value bool) simpleQueryStringType {
+	q.putInTheField("fuzzy_transpositions", value)
+	return q
+}
+
+// AnalyzeWildcard sets the option to analyze wildcard terms in the simpleQueryStringType object.
+//
+// This method determines whether wildcard terms in the query string should be analyzed.
+// When set to true, wildcard terms (* and ?) will be analyzed by the analyzer defined
+// for the field, allowing for more accurate searches when using wildcards.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Fo*").AnalyzeWildcard(true)
+//	// q now analyzes wildcard terms in the query string.
+//
+// Parameters:
+//   - value: A boolean indicating whether wildcard terms should be analyzed (true) or not (false).
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "analyze_wildcard" option set.
+func (q simpleQueryStringType) AnalyzeWildcard(value bool) simpleQueryStringType {
+	q.putInTheField("analyze_wildcard", value)
+	return q
+}
+
+// AutoGenerateSynonymsPhraseQuery sets the option to automatically generate phrase queries for synonyms in the simpleQueryStringType object.
+//
+// This method enables or disables the automatic generation of phrase queries for synonyms in the query string.
+// When set to true, Elasticsearch will automatically create phrase queries for terms that have synonyms,
+// which can improve search accuracy when working with synonym filters.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("quick brown fox").AutoGenerateSynonymsPhraseQuery(true)
+//	// q now automatically generates phrase queries for synonyms in the query string.
+//
+// Parameters:
+//   - value: A boolean indicating whether to automatically generate phrase queries for synonyms (true) or not (false).
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "auto_generate_synonyms_phrase_query" option set.
+func (q simpleQueryStringType) AutoGenerateSynonymsPhraseQuery(value bool) simpleQueryStringType {
+	q.putInTheField("auto_generate_synonyms_phrase_query", value)
+	return q
+}
+
+// Flags sets the flags for the simpleQueryStringType object.
+//
+// This method specifies which features of the simple_query_string query should be enabled.
+// It allows fine-grained control over the query's behavior by enabling or disabling specific features.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo Bar").Flags("AND|OR|PREFIX")
+//	// q now enables AND, OR, and PREFIX features for the query.
+//
+// Parameters:
+//   - value: A string representing the enabled features, separated by '|'.
+//     Possible values include: ALL, NONE, AND, OR, NOT, PREFIX, PHRASE, PRECEDENCE, ESCAPE, WHITESPACE, FUZZY, NEAR, SLOP.
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "flags" option set.
+func (q simpleQueryStringType) Flags(value string) simpleQueryStringType {
+	q.putInTheField("flags", value)
+	return q
+}
+
+// Lenient sets the leniency option for the simpleQueryStringType object.
+//
+// This method determines whether the query should be lenient when encountering
+// errors, such as analyzing incompatible fields. When set to true, the query will
+// ignore such errors, allowing for more flexible and fault-tolerant searches,
+// especially in cases where the data types may not match perfectly.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo Bar").Lenient(true)
+//	// q is now lenient, allowing it to tolerate errors during the query.
+//
+// Parameters:
+//   - value: A boolean indicating whether leniency is enabled (true) or disabled (false).
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "lenient" option set.
+func (q simpleQueryStringType) Lenient(value bool) simpleQueryStringType {
+	q.putInTheField("lenient", value)
+	return q
+}
+
+// QuoteFieldSuffix sets the field suffix to be used for quoted text in the simpleQueryStringType object.
+//
+// This method specifies a suffix to be appended to the field names when analyzing quoted text in the query string.
+// This is useful for applying different analyzers or field mappings to quoted phrases compared to unquoted terms.
+//
+// Example usage:
+//
+//	q := SimpleQueryString("Foo \"Bar Baz\"").QuoteFieldSuffix("_phrase")
+//	// q now appends "_phrase" to the field names when processing quoted text in the query string.
+//
+// Parameters:
+//   - value: A string representing the suffix to be appended to field names for quoted text.
+//
+// Returns:
+//
+// The updated simpleQueryStringType object with the "quote_field_suffix" option set.
+func (q simpleQueryStringType) QuoteFieldSuffix(value string) simpleQueryStringType {
+	q.putInTheField("quote_field_suffix", value)
+	return q
+}
+
+func (q simpleQueryStringType) putInTheField(key string, value any) simpleQueryStringType {
+	for field := range q {
+		if fieldObject, ok := q[field].(Object); ok {
+			fieldObject[key] = value
+		}
+	}
+	return q
+}

--- a/es/simple_query_string.go
+++ b/es/simple_query_string.go
@@ -208,7 +208,8 @@ func (q simpleQueryStringType) AnalyzeWildcard(value bool) simpleQueryStringType
 	return q
 }
 
-// AutoGenerateSynonymsPhraseQuery sets the option to automatically generate phrase queries for synonyms in the simpleQueryStringType object.
+// AutoGenerateSynonymsPhraseQuery sets the option to automatically generate phrase queries for synonyms
+// in the simpleQueryStringType object.
 //
 // This method enables or disables the automatic generation of phrase queries for synonyms in the query string.
 // When set to true, Elasticsearch will automatically create phrase queries for terms that have synonyms,

--- a/es/simple_query_string_test.go
+++ b/es/simple_query_string_test.go
@@ -1,0 +1,216 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+func Test_SimpleQueryString_should_exist_on_es_package(t *testing.T) {
+	// Given When
+	assert.NotNil(t, es.SimpleQueryString[any])
+}
+
+func Test_SimpleQueryString_method_should_create_simpleQueryStringType(t *testing.T) {
+	// Given When
+	b := es.SimpleQueryString("value")
+
+	// Then
+	assert.NotNil(t, b)
+	assert.IsTypeString(t, "es.simpleQueryStringType", b)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_required_query(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value"),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_fields(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").Fields([]string{"field1", "field2"}),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"fields\":[\"field1\",\"field2\"],\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_analyzer(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").Analyzer("standard"),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"analyzer\":\"standard\",\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_default_operator(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").DefaultOperator("AND"),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"default_operator\":\"AND\",\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_minimum_should_match(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").MinimumShouldMatch("2"),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"minimum_should_match\":\"2\",\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_fuzzy_max_expansions(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").FuzzyMaxExpansions(50),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"fuzzy_max_expansions\":50,\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_fuzzy_prefix_length(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").FuzzyPrefixLength(2),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"fuzzy_prefix_length\":2,\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_fuzzy_transpositions(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").FuzzyTranspositions(true),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"fuzzy_transpositions\":true,\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_analyze_wildcard(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").AnalyzeWildcard(true),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"analyze_wildcard\":true,\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_auto_generate_synonyms_phrase_query(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").AutoGenerateSynonymsPhraseQuery(true),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"auto_generate_synonyms_phrase_query\":true,\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_flags(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").Flags("AND|OR|PREFIX"),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"flags\":\"AND|OR|PREFIX\",\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_lenient(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").Lenient(true),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"lenient\":true,\"query\":\"value\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_quote_field_suffix(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").QuoteFieldSuffix("_phrase"),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{\"query\":\"value\",\"quote_field_suffix\":\"_phrase\"}}}", bodyJSON)
+}
+
+func Test_SimpleQueryString_method_should_create_simple_query_string_with_all_parameters(t *testing.T) {
+	// Given When
+	b := es.NewQuery(
+		es.SimpleQueryString("value").
+			Fields([]string{"field1", "field2"}).
+			Analyzer("standard").
+			DefaultOperator("AND").
+			MinimumShouldMatch("2").
+			FuzzyMaxExpansions(50).
+			FuzzyPrefixLength(2).
+			FuzzyTranspositions(true).
+			AnalyzeWildcard(true).
+			AutoGenerateSynonymsPhraseQuery(true).
+			Flags("AND|OR|PREFIX").
+			Lenient(true).
+			QuoteFieldSuffix("_phrase"),
+	)
+
+	// Then
+	assert.NotNil(t, b)
+	bodyJSON := assert.MarshalWithoutError(t, b)
+	assert.Equal(t, "{\"query\":{\"simple_query_string\":{"+
+		"\"analyze_wildcard\":true,"+
+		"\"analyzer\":\"standard\","+
+		"\"auto_generate_synonyms_phrase_query\":true,"+
+		"\"default_operator\":\"AND\","+
+		"\"fields\":[\"field1\",\"field2\"],"+
+		"\"flags\":\"AND|OR|PREFIX\","+
+		"\"fuzzy_max_expansions\":50,"+
+		"\"fuzzy_prefix_length\":2,"+
+		"\"fuzzy_transpositions\":true,"+
+		"\"lenient\":true,"+
+		"\"minimum_should_match\":\"2\","+
+		"\"query\":\"value\","+
+		"\"quote_field_suffix\":\"_phrase\""+
+		"}}}", bodyJSON)
+}

--- a/internal/testing/simple_query_string_test.go
+++ b/internal/testing/simple_query_string_test.go
@@ -1,0 +1,46 @@
+package testing
+
+import (
+	"encoding/json"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/bayraktugrul/go-await"
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *testSuite) Test_it_should_return_documents_that_filtered_by_simple_query_string_with_wildcard_or_operator() {
+	// Given
+	foo := FooDocument{
+		Id:  "10",
+		Foo: "foo",
+	}
+	bar := FooDocument{
+		Id:  "20",
+		Foo: "bar",
+	}
+	george := FooDocument{
+		Id:  "30",
+		Foo: "george orwell",
+	}
+	s.ElasticsearchRepository.BulkInsert([]FooDocument{foo, bar, george})
+	await.New().Await(func() bool { return s.ElasticsearchRepository.Exists(foo.Id) })
+	await.New().Await(func() bool { return s.ElasticsearchRepository.Exists(bar.Id) })
+	await.New().Await(func() bool { return s.ElasticsearchRepository.Exists(george.Id) })
+
+	query := es.NewQuery(
+		es.Bool().Must(
+			es.SimpleQueryString[string]("ge* OR bar").AnalyzeWildcard(true)),
+	)
+	bodyJSON, _ := json.Marshal(query)
+
+	// When
+	result, err := s.ElasticsearchRepository.Search(string(bodyJSON))
+
+	// Then
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), len(result), 2)
+	assert.Equal(s.T(), result[0].Foo, "george orwell")
+	assert.Equal(s.T(), result[1].Foo, "bar")
+
+	s.ElasticsearchRepository.BulkDelete([]string{foo.Id, bar.Id, george.Id})
+}


### PR DESCRIPTION
- Add Simple Query String feature

This addition allows users to easily construct Simple Query String queries with full support for all available options, enhancing the flexibility and power of the query builder.

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html 