### PR TITLE
feature: Add `adjust_pure_negative` flag to Bool query

### DIFF
--- a/es/bool_query.go
+++ b/es/bool_query.go
@@ -51,6 +51,30 @@ func (b BoolType) MinimumShouldMatch(minimumShouldMatch int) BoolType {
 	return b
 }
 
+// AdjustPureNegative sets the "adjust_pure_negative" parameter in a BoolType query.
+//
+// This method allows you to specify whether pure negative queries should be
+// adjusted or not. When set to true, the query will be adjusted to include
+// pure negative queries, which can influence the matching behavior of the
+// boolean query.
+//
+// Example usage:
+//
+//	b := Bool().AdjustPureNegative(true)
+//	// b now includes an "adjust_pure_negative" parameter set to true.
+//
+// Parameters:
+//   - adjustPureNegative: A boolean value indicating whether to adjust
+//     pure negative queries in the boolean query.
+//
+// Returns:
+//
+//	The updated BoolType object with the "adjust_pure_negative" parameter set.
+func (b BoolType) AdjustPureNegative(adjustPureNegative bool) BoolType {
+	b["adjust_pure_negative"] = adjustPureNegative
+	return b
+}
+
 // Boost sets the "boost" parameter in a BoolType query.
 //
 // This method allows you to assign a boost value to a boolean query, which

--- a/es/bool_query_test.go
+++ b/es/bool_query_test.go
@@ -44,6 +44,27 @@ func Test_Bool_MinimumShouldMatch_should_create_json_with_minimum_should_match_f
 	assert.Equal(t, "{\"query\":{\"bool\":{\"minimum_should_match\":7}}}", bodyJSON)
 }
 
+func Test_Bool_should_have_AdjustPureNegative_method(t *testing.T) {
+	// Given
+	b := es.Bool()
+
+	// When Then
+	assert.NotNil(t, b.AdjustPureNegative)
+}
+
+func Test_Bool_AdjustPureNegative_should_create_json_with_adjust_pure_negative_field_inside_bool(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Bool().
+			AdjustPureNegative(false),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"bool\":{\"adjust_pure_negative\":false}}}", bodyJSON)
+}
+
 func Test_Bool_should_have_Boost_method(t *testing.T) {
 	// Given
 	b := es.Bool()


### PR DESCRIPTION
This flag allows adjustment of pure negative queries within the boolean query.