### PR TITLE
feature: refactor `term` query and add `case_insensitive` and `boost` parameters

### DIFF
--- a/benchmarks/aggs_example_test.go
+++ b/benchmarks/aggs_example_test.go
@@ -64,7 +64,9 @@ func createAggsQueryVanilla() map[string]any {
 				"must": []map[string]interface{}{
 					{
 						"term": map[string]interface{}{
-							"type": "File",
+							"type": map[string]interface{}{
+								"value": "File",
+							},
 						},
 					},
 					{

--- a/benchmarks/complex_example_test.go
+++ b/benchmarks/complex_example_test.go
@@ -87,17 +87,23 @@ func createComplexQueryVanilla(id int) map[string]any {
 							"should": []map[string]interface{}{
 								{
 									"term": map[string]interface{}{
-										"doc.id": id,
+										"doc.id": map[string]interface{}{
+											"value": id,
+										},
 									},
 								},
 								{
 									"term": map[string]interface{}{
-										"file.fileId": id,
+										"file.fileId": map[string]interface{}{
+											"value": id,
+										},
 									},
 								},
 								{
 									"term": map[string]interface{}{
-										"page.number": id,
+										"page.number": map[string]interface{}{
+											"value": id,
+										},
 									},
 								},
 							},
@@ -107,7 +113,9 @@ func createComplexQueryVanilla(id int) map[string]any {
 				"filter": []map[string]interface{}{
 					{
 						"term": map[string]interface{}{
-							"type": "File",
+							"type": map[string]interface{}{
+								"value": "File",
+							},
 						},
 					},
 					{

--- a/benchmarks/conditional_example_test.go
+++ b/benchmarks/conditional_example_test.go
@@ -60,7 +60,9 @@ func createConditionalQueryVanilla(items []int) map[string]any {
 		},
 		{
 			"term": map[string]interface{}{
-				"type": "File",
+				"type": map[string]interface{}{
+					"value": "File",
+				},
 			},
 		},
 		{

--- a/benchmarks/intermediate_example_test.go
+++ b/benchmarks/intermediate_example_test.go
@@ -49,12 +49,16 @@ func createIntermediateQueryVanilla(id int) map[string]any {
 							"should": []interface{}{
 								map[string]interface{}{
 									"term": map[string]interface{}{
-										"doc.id": id,
+										"doc.id": map[string]interface{}{
+											"value": id,
+										},
 									},
 								},
 								map[string]interface{}{
 									"term": map[string]interface{}{
-										"file.fileId": id,
+										"file.fileId": map[string]interface{}{
+											"value": id,
+										},
 									},
 								},
 							},

--- a/benchmarks/mixed_example_test.go
+++ b/benchmarks/mixed_example_test.go
@@ -42,7 +42,9 @@ func createMixedQueryVanilla() map[string]any {
 				"must": []map[string]interface{}{
 					{
 						"term": map[string]interface{}{
-							"author": "George Orwell",
+							"author": map[string]interface{}{
+								"value": "George Orwell",
+							},
 						},
 					},
 				},

--- a/benchmarks/nested_example_test.go
+++ b/benchmarks/nested_example_test.go
@@ -36,12 +36,16 @@ func createNestedQueryVanilla() map[string]any {
 								"must": []map[string]interface{}{
 									{
 										"term": map[string]interface{}{
-											"driver.vehicle.make": "Powell Motors",
+											"driver.vehicle.make": map[string]interface{}{
+												"value": "Powell Motors",
+											},
 										},
 									},
 									{
 										"term": map[string]interface{}{
-											"driver.vehicle.model": "Canyonero",
+											"driver.vehicle.model": map[string]interface{}{
+												"value": "Canyonero",
+											},
 										},
 									},
 								},

--- a/benchmarks/simple_example_test.go
+++ b/benchmarks/simple_example_test.go
@@ -24,7 +24,9 @@ func createSimpleQueryVanilla() map[string]any {
 				"filter": []map[string]interface{}{
 					{
 						"term": map[string]interface{}{
-							"id": 123456,
+							"id": map[string]interface{}{
+								"value": 123456,
+							},
 						},
 					},
 				},

--- a/benchmarks/ty_example_test.go
+++ b/benchmarks/ty_example_test.go
@@ -30,7 +30,9 @@ func createTyExampleQueryVanilla(brandIds []int64, storefrontIds []string) map[s
 				"filter": []interface{}{
 					map[string]interface{}{
 						"term": map[string]interface{}{
-							"type": "LegalRule",
+							"type": map[string]interface{}{
+								"value": "LegalRule",
+							},
 						},
 					},
 					map[string]interface{}{

--- a/es/bool_query_test.go
+++ b/es/bool_query_test.go
@@ -141,7 +141,7 @@ func Test_Filter_method_should_hold_items(t *testing.T) {
 	assert.IsTypeString(t, "es.FilterType", filter)
 
 	bodyJSON := assert.MarshalWithoutError(t, b)
-	assert.Equal(t, "{\"filter\":[{\"term\":{\"id\":12345}}]}", bodyJSON)
+	assert.Equal(t, "{\"filter\":[{\"term\":{\"id\":{\"value\":12345}}}]}", bodyJSON)
 }
 
 ////   Bool.Must   ////
@@ -188,7 +188,7 @@ func Test_Must_method_should_hold_items(t *testing.T) {
 	assert.IsTypeString(t, "es.MustType", must)
 
 	bodyJSON := assert.MarshalWithoutError(t, b)
-	assert.Equal(t, "{\"must\":[{\"term\":{\"id\":12345}}]}", bodyJSON)
+	assert.Equal(t, "{\"must\":[{\"term\":{\"id\":{\"value\":12345}}}]}", bodyJSON)
 }
 
 ////   Bool.MustNot   ////
@@ -235,7 +235,7 @@ func Test_MustNot_method_should_hold_items(t *testing.T) {
 	assert.IsTypeString(t, "es.MustNotType", mustNot)
 
 	bodyJSON := assert.MarshalWithoutError(t, b)
-	assert.Equal(t, "{\"must_not\":[{\"term\":{\"id\":12345}}]}", bodyJSON)
+	assert.Equal(t, "{\"must_not\":[{\"term\":{\"id\":{\"value\":12345}}}]}", bodyJSON)
 }
 
 ////   Bool.Should   ////
@@ -282,5 +282,5 @@ func Test_Should_method_should_hold_items(t *testing.T) {
 	assert.IsTypeString(t, "es.ShouldType", should)
 
 	bodyJSON := assert.MarshalWithoutError(t, b)
-	assert.Equal(t, "{\"should\":[{\"term\":{\"id\":12345}}]}", bodyJSON)
+	assert.Equal(t, "{\"should\":[{\"term\":{\"id\":{\"value\":12345}}}]}", bodyJSON)
 }

--- a/es/condition/if_test.go
+++ b/es/condition/if_test.go
@@ -24,7 +24,7 @@ func Test_Condition_If_should_add_Term_When_condition_is_true(t *testing.T) {
 	// Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
-	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"language\":\"en\"}},{\"exists\":{\"field\":\"brandId\"}}]}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"language\":{\"value\":\"en\"}}},{\"exists\":{\"field\":\"brandId\"}}]}}}", bodyJSON)
 }
 
 func Test_Condition_If_should_not_add_Term_When_condition_is_not_true(t *testing.T) {

--- a/es/condition/if_test.go
+++ b/es/condition/if_test.go
@@ -24,6 +24,7 @@ func Test_Condition_If_should_add_Term_When_condition_is_true(t *testing.T) {
 	// Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
 	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"language\":{\"value\":\"en\"}}},{\"exists\":{\"field\":\"brandId\"}}]}}}", bodyJSON)
 }
 

--- a/es/range_test.go
+++ b/es/range_test.go
@@ -30,7 +30,7 @@ func Test_Range_should_add_range_field_when_inside_query(t *testing.T) {
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
 	// nolint:golint,lll
-	assert.Equal(t, "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"age\":{\"gte\":10,\"lte\":20}}},{\"term\":{\"language\":\"tr\"}}]}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"age\":{\"gte\":10,\"lte\":20}}},{\"term\":{\"language\":{\"value\":\"tr\"}}}]}}}", bodyJSON)
 }
 
 func Test_Range_method_should_create_rangeType(t *testing.T) {

--- a/es/term_query.go
+++ b/es/term_query.go
@@ -63,6 +63,29 @@ func (t termType) CaseInsensitive(caseInsensitive bool) termType {
 	return t.putInTheField("case_insensitive", caseInsensitive)
 }
 
+// Boost sets the "boost" parameter in a termType query.
+//
+// This method allows you to specify a boost factor for the term query,
+// which influences the relevance score of matching documents. A higher
+// boost value increases the importance of the term in the query,
+// resulting in higher scores for documents that match this term.
+//
+// Example usage:
+//
+//	t := Term().Boost(1.5)
+//	// t now includes a "boost" parameter set to 1.5.
+//
+// Parameters:
+//   - boost: A float64 value representing the boost factor for the term
+//     query.
+//
+// Returns:
+//
+//	The updated termType object with the "boost" parameter set.
+func (t termType) Boost(boost float64) termType {
+	return t.putInTheField("boost", boost)
+}
+
 // TermFunc creates a termType object based on a condition evaluated by a function.
 //
 // This function conditionally creates a termType object if the provided function

--- a/es/term_query.go
+++ b/es/term_query.go
@@ -23,9 +23,44 @@ type termType Object
 func Term[T any](key string, value T) termType {
 	return termType{
 		"term": Object{
-			key: value,
+			key: Object{
+				"value": value,
+			},
 		},
 	}
+}
+
+func (t termType) putInTheField(key string, value any) termType {
+	if term, ok := t["term"].(Object); ok {
+		for field := range term {
+			if fieldObject, foOk := term[field].(Object); foOk {
+				fieldObject[key] = value
+			}
+		}
+	}
+	return t
+}
+
+// CaseInsensitive sets the "case_insensitive" parameter in a termType query.
+//
+// This method allows you to specify whether the term query should be case-
+// insensitive. When set to true, the term matching will ignore case,
+// allowing for more flexible matches in the query results.
+//
+// Example usage:
+//
+//	t := Term().CaseInsensitive(true)
+//	// t now includes a "case_insensitive" parameter set to true.
+//
+// Parameters:
+//   - caseInsensitive: A boolean value indicating whether the term query
+//     should be case-insensitive.
+//
+// Returns:
+//
+//	The updated termType object with the "case_insensitive" parameter set.
+func (t termType) CaseInsensitive(caseInsensitive bool) termType {
+	return t.putInTheField("case_insensitive", caseInsensitive)
 }
 
 // TermFunc creates a termType object based on a condition evaluated by a function.

--- a/es/term_query_test.go
+++ b/es/term_query_test.go
@@ -132,6 +132,7 @@ func Test_TermFunc_should_add_only_term_fields_inside_the_query_when_callback_re
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
 	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"a\":{\"value\":\"b\"}}},{\"term\":{\"e\":{\"value\":\"f\"}}}]}}}", bodyJSON)
 }
 
@@ -191,6 +192,7 @@ func Test_TermIf_should_add_only_term_fields_inside_the_query_when_condition_is_
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
 	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"a\":{\"value\":\"b\"}}},{\"term\":{\"e\":{\"value\":\"f\"}}}]}}}", bodyJSON)
 }
 

--- a/es/term_query_test.go
+++ b/es/term_query_test.go
@@ -23,7 +23,7 @@ func Test_Term_should_create_json_with_term_field_inside_query(t *testing.T) {
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
-	assert.Equal(t, "{\"query\":{\"term\":{\"key\":\"value\"}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"term\":{\"key\":{\"value\":\"value\"}}}}", bodyJSON)
 }
 
 func Test_Term_method_should_create_termType(t *testing.T) {
@@ -33,6 +33,27 @@ func Test_Term_method_should_create_termType(t *testing.T) {
 	// Then
 	assert.NotNil(t, b)
 	assert.IsTypeString(t, "es.termType", b)
+}
+
+func Test_Term_should_have_CaseInsensitive_method(t *testing.T) {
+	// Given
+	term := es.Term("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.CaseInsensitive)
+}
+
+func Test_Term_CaseInsensitive_should_create_json_with_case_insensitive_field_inside_term(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Term("type", "File").
+			CaseInsensitive(true),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"term\":{\"type\":{\"case_insensitive\":true,\"value\":\"File\"}}}}", bodyJSON)
 }
 
 ////   TermFunc   ////
@@ -53,7 +74,7 @@ func Test_TermFunc_should_create_json_with_term_field_inside_query(t *testing.T)
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
-	assert.Equal(t, "{\"query\":{\"term\":{\"key\":\"value\"}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"term\":{\"key\":{\"value\":\"value\"}}}}", bodyJSON)
 }
 
 func Test_TermFunc_should_not_add_term_field_inside_query_when_callback_result_is_false(t *testing.T) {
@@ -90,7 +111,7 @@ func Test_TermFunc_should_add_only_term_fields_inside_the_query_when_callback_re
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
-	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"a\":\"b\"}},{\"term\":{\"e\":\"f\"}}]}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"a\":{\"value\":\"b\"}}},{\"term\":{\"e\":{\"value\":\"f\"}}}]}}}", bodyJSON)
 }
 
 func Test_TermFunc_method_should_create_termType(t *testing.T) {
@@ -120,7 +141,7 @@ func Test_TermIf_should_create_json_with_term_field_inside_query(t *testing.T) {
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
-	assert.Equal(t, "{\"query\":{\"term\":{\"key\":\"value\"}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"term\":{\"key\":{\"value\":\"value\"}}}}", bodyJSON)
 }
 
 func Test_TermIf_should_not_add_term_field_inside_query_when_condition_is_false(t *testing.T) {
@@ -149,7 +170,7 @@ func Test_TermIf_should_add_only_term_fields_inside_the_query_when_condition_is_
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
-	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"a\":\"b\"}},{\"term\":{\"e\":\"f\"}}]}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"a\":{\"value\":\"b\"}}},{\"term\":{\"e\":{\"value\":\"f\"}}}]}}}", bodyJSON)
 }
 
 func Test_TermIf_method_should_create_termType(t *testing.T) {

--- a/es/term_query_test.go
+++ b/es/term_query_test.go
@@ -56,6 +56,27 @@ func Test_Term_CaseInsensitive_should_create_json_with_case_insensitive_field_in
 	assert.Equal(t, "{\"query\":{\"term\":{\"type\":{\"case_insensitive\":true,\"value\":\"File\"}}}}", bodyJSON)
 }
 
+func Test_Term_should_have_Boost_method(t *testing.T) {
+	// Given
+	term := es.Term("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.CaseInsensitive)
+}
+
+func Test_Term_Boost_should_create_json_with_boost_field_inside_term(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Term("type", "File").
+			Boost(3.14),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"term\":{\"type\":{\"boost\":3.14,\"value\":\"File\"}}}}", bodyJSON)
+}
+
 ////   TermFunc   ////
 
 func Test_TermFunc_should_exist_on_es_package(t *testing.T) {


### PR DESCRIPTION
To enable adding optional parameters to the term query, it needs to be refactored;

from:
```js
{
    "term": {
        "Foo": "Bar"
    }
}
```

to:
```js
{
    "term": {
        "Foo": {
            "value": "Bar"
        }
    }
}
```

Other than that, we now have 2 new parameters for `term` query.

1. case_insensitive
2. boost