### PR TITLE
bugfix: Document ID Issue in `BulkInsert`

### DIFF
--- a/internal/testing/elasticsearch_repository.go
+++ b/internal/testing/elasticsearch_repository.go
@@ -68,7 +68,7 @@ func (e *elasticsearchRepository) BulkInsert(documents []FooDocument) error {
 	var bulkRequestBody strings.Builder
 
 	for i := range documents {
-		meta := fmt.Sprintf(`{"index":{"_index":"%s","_id":"%s"}}%s`, constants.TestIndex, documents[i], "\n")
+		meta := fmt.Sprintf(`{"index":{"_index":"%s","_id":"%s"}}%s`, constants.TestIndex, documents[i].Id, "\n")
 		bulkRequestBody.WriteString(meta)
 
 		docJson, err := json.Marshal(documents[i])


### PR DESCRIPTION
This PR fixes a bug where the wrong document ID was used in Elasticsearch bulk indexing. The line was updated to reference documents[i].Id instead of documents[i], ensuring documents are indexed with the correct IDs.
This bug led to inserting documents with incorrect IDs, which resulted in not being able to delete the documents accurately using their IDs.

<img width="576" alt="Screenshot 2024-10-29 at 00 58 24" src="https://github.com/user-attachments/assets/f8f297ed-7fcb-4c8a-bc8d-ea948e7363f4">




