### PR TITLE
feature: Add support for Percentage and Combination `minimum_should_match` 

### DIFF
--- a/es/bool_query.go
+++ b/es/bool_query.go
@@ -46,7 +46,7 @@ func Bool() BoolType {
 // Returns:
 //
 //	The updated BoolType object with the "minimum_should_match" parameter set.
-func (b BoolType) MinimumShouldMatch(minimumShouldMatch int) BoolType {
+func (b BoolType) MinimumShouldMatch(minimumShouldMatch any) BoolType {
 	b["minimum_should_match"] = minimumShouldMatch
 	return b
 }

--- a/es/bool_query_test.go
+++ b/es/bool_query_test.go
@@ -31,7 +31,7 @@ func Test_Bool_should_have_MinimumShouldMatch_method(t *testing.T) {
 	assert.NotNil(t, b.MinimumShouldMatch)
 }
 
-func Test_Bool_MinimumShouldMatch_should_create_json_with_minimum_should_match_field_inside_bool(t *testing.T) {
+func Test_Bool_MinimumShouldMatch_should_create_json_with_int_minimum_should_match_field_inside_bool(t *testing.T) {
 	// Given
 	query := es.NewQuery(
 		es.Bool().
@@ -42,6 +42,19 @@ func Test_Bool_MinimumShouldMatch_should_create_json_with_minimum_should_match_f
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
 	assert.Equal(t, "{\"query\":{\"bool\":{\"minimum_should_match\":7}}}", bodyJSON)
+}
+
+func Test_Bool_MinimumShouldMatch_should_create_json_with_string_minimum_should_match_field_inside_bool(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Bool().
+			MinimumShouldMatch("2<-25% 9<-3"),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"bool\":{\"minimum_should_match\":\"2\\u003c-25% 9\\u003c-3\"}}}", bodyJSON)
 }
 
 func Test_Bool_should_have_AdjustPureNegative_method(t *testing.T) {


### PR DESCRIPTION
`minimum_should_match` can be set to `75%` or `3<90%`. For this, it needs to be able to take string parameters.

[Referance: Elastic - minimum_should_match parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html)