### PR TITLE
feature: Add remaining `Match Query` parameters

### DIFF
--- a/es/enums/match/operator/operator.go
+++ b/es/enums/match/operator/operator.go
@@ -7,7 +7,7 @@ package operator
 //
 // Example usage:
 //
-//	match := Match("field", "value").Operator(Operator.And)
+//	match := es.Match("field", "value").Operator(Operator.And)
 //	// match now has the "operator" field set to "and" in the matchType object.
 //
 // Parameters:

--- a/es/enums/match/operator/operator_test.go
+++ b/es/enums/match/operator/operator_test.go
@@ -3,11 +3,12 @@ package operator_test
 import (
 	"testing"
 
-	Operator "github.com/Trendyol/es-query-builder/es/enums/match/operator"
 	"github.com/Trendyol/es-query-builder/test/assert"
+
+	Operator "github.com/Trendyol/es-query-builder/es/enums/match/operator"
 )
 
-func Test_ScoreModeString(t *testing.T) {
+func Test_OperatorString(t *testing.T) {
 	tests := []struct {
 		operator Operator.Operator
 		result   string

--- a/es/enums/match/zero-terms-query/zero_terms_query.go
+++ b/es/enums/match/zero-terms-query/zero_terms_query.go
@@ -8,7 +8,7 @@ package zerotermsquery
 //
 // Example usage:
 //
-//	match := Match("field", "value").ZeroTermsQuery(ZeroTermsQuery.All)
+//	match := es.Match("field", "value").ZeroTermsQuery(ZeroTermsQuery.All)
 //	// match now has the "zero_terms_query" field set to "all" in the matchType object.
 //
 // Parameters:

--- a/es/enums/match/zero-terms-query/zero_terms_query.go
+++ b/es/enums/match/zero-terms-query/zero_terms_query.go
@@ -1,0 +1,33 @@
+package zerotermsquery
+
+// ZeroTermsQuery sets the "zero_terms_query" field in the matchType object.
+//
+// This method specifies the behavior of the match query when no terms remain after analysis,
+// such as when all terms are stop words. It updates the matchType object to include the provided
+// zeroTermsQuery value, which determines how the query should respond in this scenario.
+//
+// Example usage:
+//
+//	match := Match("field", "value").ZeroTermsQuery(ZeroTermsQuery.All)
+//	// match now has the "zero_terms_query" field set to "all" in the matchType object.
+//
+// Parameters:
+//   - zeroTermsQuery: A ZeroTermsQuery value indicating the behavior for zero-term queries.
+//     It can be either ZeroTermsQuery.All or ZeroTermsQuery.None.
+//
+// Returns:
+//
+//	The updated matchType object with the "zero_terms_query" field set to the specified value.
+type ZeroTermsQuery string
+
+const (
+	// All indicates that all documents should be matched when no terms remain.
+	All ZeroTermsQuery = "all"
+
+	// None indicates that no documents should be matched when no terms remain.
+	None ZeroTermsQuery = "none"
+)
+
+func (zeroTermsQuery ZeroTermsQuery) String() string {
+	return string(zeroTermsQuery)
+}

--- a/es/enums/match/zero-terms-query/zero_terms_query_test.go
+++ b/es/enums/match/zero-terms-query/zero_terms_query_test.go
@@ -1,0 +1,3 @@
+package zerotermsquery_test
+
+// TODO: write test

--- a/es/enums/match/zero-terms-query/zero_terms_query_test.go
+++ b/es/enums/match/zero-terms-query/zero_terms_query_test.go
@@ -1,3 +1,25 @@
 package zerotermsquery_test
 
-// TODO: write test
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/test/assert"
+
+	ZeroTermsQuery "github.com/Trendyol/es-query-builder/es/enums/match/zero-terms-query"
+)
+
+func Test_ZeroTermsQueryString(t *testing.T) {
+	tests := []struct {
+		zeroTermsQuery ZeroTermsQuery.ZeroTermsQuery
+		result         string
+	}{
+		{ZeroTermsQuery.All, "all"},
+		{ZeroTermsQuery.None, "none"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.result, func(t *testing.T) {
+			assert.Equal(t, test.result, test.zeroTermsQuery.String())
+		})
+	}
+}

--- a/es/match_all_query.go
+++ b/es/match_all_query.go
@@ -32,8 +32,7 @@ func (m matchAllType) putInTheField(key string, value any) matchAllType {
 // Boost sets the "boost" field in the match_all query.
 //
 // This method configures the match_all query to use a specified boost factor, which influences
-// the relevance scoring of the matched documents. It calls putInTheField to add or update
-// the "boost" key in the match_all query object.
+// the relevance scoring of the matched documents.
 //
 // Example usage:
 //

--- a/es/match_query.go
+++ b/es/match_query.go
@@ -50,8 +50,7 @@ func (m matchType) putInTheField(key string, value any) matchType {
 // Operator sets the "operator" field in the match query.
 //
 // This method configures the match query to use a specified operator (e.g., "AND" or "OR")
-// for the matching process. It calls putInTheField to add or update the "operator" key
-// in the match query object.
+// for the matching process.
 //
 // Example usage:
 //
@@ -71,8 +70,7 @@ func (m matchType) Operator(operator Operator.Operator) matchType {
 // Boost sets the "boost" field in the match query.
 //
 // This method configures the match query to use a specified boost factor, which influences
-// the relevance scoring of the matched documents. It calls putInTheField to add or update
-// the "boost" key in the match query object.
+// the relevance scoring of the matched documents.
 //
 // Example usage:
 //
@@ -94,7 +92,6 @@ func (m matchType) Boost(boost float64) matchType {
 // This method configures the match query to use a specified cutoff frequency, which is useful
 // for controlling how often terms should appear in the document for it to be considered a match.
 // A lower cutoff frequency increases precision, while a higher one allows more terms to be matched.
-// It calls putInTheField to add or update the "cutoff_frequency" key in the match query object.
 //
 // Example usage:
 //
@@ -116,7 +113,6 @@ func (m matchType) CutoffFrequency(cutoffFrequency float64) matchType {
 // This method configures the match query to use a specified fuzziness level, which determines
 // the allowed edit distance (e.g., number of character changes) for a term to be considered a match.
 // Common values include "AUTO", or integers representing the number of edits (e.g., 1 or 2).
-// It calls putInTheField to add or update the "fuzziness" key in the match query object.
 //
 // Example usage:
 //
@@ -138,7 +134,7 @@ func (m matchType) Fuzziness(fuzziness any) matchType {
 // This method configures the match query to use a specified fuzzy rewrite method,
 // which controls how multi-term queries are rewritten. Common values include "constant_score",
 // "scoring_boolean", and other rewrite options that influence the scoring and performance of
-// fuzzy matching. It calls putInTheField to add or update the "fuzzy_rewrite" key in the match query object.
+// fuzzy matching.
 //
 // Example usage:
 //
@@ -159,8 +155,7 @@ func (m matchType) FuzzyRewrite(fuzzyRewrite string) matchType {
 //
 // This method configures the match query to allow or disallow transpositions (e.g., swapping two adjacent characters)
 // when performing fuzzy matching. Setting this field to true enables transpositions, which can increase the match rate
-// for terms with common typos or character swaps. It calls putInTheField to add or update the "fuzzy_transpositions" key
-// in the match query object.
+// for terms with common typos or character swaps.
 //
 // Example usage:
 //
@@ -182,7 +177,6 @@ func (m matchType) FuzzyTranspositions(fuzzyTranspositions bool) matchType {
 // This method configures the match query to use lenient parsing, allowing it to skip errors
 // for data type mismatches. When set to true, documents that contain mismatched data types
 // (e.g., text in a numeric field) will not cause errors and will be ignored instead.
-// It calls putInTheField to add or update the "lenient" key in the match query object.
 //
 // Example usage:
 //
@@ -203,8 +197,7 @@ func (m matchType) Lenient(lenient bool) matchType {
 //
 // This method configures the match query to limit the maximum number of terms that can be expanded
 // for multi-term queries, such as those involving fuzzy matching. Higher values allow more terms to
-// be considered, but may impact performance. It calls putInTheField to add or update the "max_expansions"
-// key in the match query object.
+// be considered, but may impact performance.
 //
 // Example usage:
 //
@@ -226,8 +219,7 @@ func (m matchType) MaxExpansions(maxExpansions int) matchType {
 // This method configures the match query to specify a minimum prefix length for fuzzy matching,
 // which defines the number of initial characters in a term that must match exactly before
 // considering fuzziness. Increasing this value can improve performance by reducing the number
-// of fuzzy matches, but may also limit the flexibility of the query. It calls putInTheField
-// to add or update the "prefix_length" key in the match query object.
+// of fuzzy matches, but may also limit the flexibility of the query.
 //
 // Example usage:
 //
@@ -249,7 +241,7 @@ func (m matchType) PrefixLength(prefixLength int) matchType {
 // This method configures the behavior of the match query when no terms remain after analysis
 // (for example, if all terms are stop words). The specified zero_terms_query value determines
 // how to handle this scenario, with options like "all" to match all documents or "none" to
-// match none. It calls putInTheField to add or update the "zero_terms_query" key in the match query object.
+// match none.
 //
 // Example usage:
 //

--- a/es/match_query.go
+++ b/es/match_query.go
@@ -1,6 +1,9 @@
 package es
 
-import Operator "github.com/Trendyol/es-query-builder/es/enums/match/operator"
+import (
+	Operator "github.com/Trendyol/es-query-builder/es/enums/match/operator"
+	ZeroTermsQuery "github.com/Trendyol/es-query-builder/es/enums/match/zero-terms-query"
+)
 
 type matchType Object
 
@@ -12,7 +15,7 @@ type matchType Object
 //
 // Example usage:
 //
-//	m := Match("title", "es-query-builder")
+//	m := es.Match("title", "es-query-builder")
 //	// m now contains a matchType object that matches the query "es-query-builder" in the "title" field.
 //
 // Parameters:
@@ -52,7 +55,7 @@ func (m matchType) putInTheField(key string, value any) matchType {
 //
 // Example usage:
 //
-//	m := Match("title", "es-query-builder").Operator("AND")
+//	m := es.Match("title", "es-query-builder").Operator("AND")
 //	// m now has an "operator" field set to "AND" in the match query object.
 //
 // Parameters:
@@ -73,7 +76,7 @@ func (m matchType) Operator(operator Operator.Operator) matchType {
 //
 // Example usage:
 //
-//	m := Match("title", "es-query-builder").Boost(1.5)
+//	m := es.Match("title", "es-query-builder").Boost(1.5)
 //	// m now has a "boost" field set to 1.5 in the match query object.
 //
 // Parameters:
@@ -84,4 +87,181 @@ func (m matchType) Operator(operator Operator.Operator) matchType {
 //	The updated matchType object with the "boost" field set to the specified value.
 func (m matchType) Boost(boost float64) matchType {
 	return m.putInTheField("boost", boost)
+}
+
+// CutoffFrequency sets the "cutoff_frequency" field in the match query.
+//
+// This method configures the match query to use a specified cutoff frequency, which is useful
+// for controlling how often terms should appear in the document for it to be considered a match.
+// A lower cutoff frequency increases precision, while a higher one allows more terms to be matched.
+// It calls putInTheField to add or update the "cutoff_frequency" key in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").CutoffFrequency(0.001)
+//	// m now has a "cutoff_frequency" field set to 0.001 in the match query object.
+//
+// Parameters:
+//   - cutoffFrequency: A float64 value representing the cutoff frequency threshold to be used in the match query.
+//
+// Returns:
+//
+//	The updated matchType object with the "cutoff_frequency" field set to the specified value.
+func (m matchType) CutoffFrequency(cutoffFrequency float64) matchType {
+	return m.putInTheField("cutoff_frequency", cutoffFrequency)
+}
+
+// Fuzziness sets the "fuzziness" field in the match query.
+//
+// This method configures the match query to use a specified fuzziness level, which determines
+// the allowed edit distance (e.g., number of character changes) for a term to be considered a match.
+// Common values include "AUTO", or integers representing the number of edits (e.g., 1 or 2).
+// It calls putInTheField to add or update the "fuzziness" key in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").Fuzziness("AUTO")
+//	// m now has a "fuzziness" field set to "AUTO" in the match query object.
+//
+// Parameters:
+//   - fuzziness: A value of any type (typically a string or integer) representing the fuzziness level to be applied to the match query.
+//
+// Returns:
+//
+//	The updated matchType object with the "fuzziness" field set to the specified value.
+func (m matchType) Fuzziness(fuzziness any) matchType {
+	return m.putInTheField("fuzziness", fuzziness)
+}
+
+// FuzzyRewrite sets the "fuzzy_rewrite" field in the match query.
+//
+// This method configures the match query to use a specified fuzzy rewrite method,
+// which controls how multi-term queries are rewritten. Common values include "constant_score",
+// "scoring_boolean", and other rewrite options that influence the scoring and performance of
+// fuzzy matching. It calls putInTheField to add or update the "fuzzy_rewrite" key in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").FuzzyRewrite("constant_score")
+//	// m now has a "fuzzy_rewrite" field set to "constant_score" in the match query object.
+//
+// Parameters:
+//   - fuzzyRewrite: A string value representing the rewrite method to be used for fuzzy matching in the match query.
+//
+// Returns:
+//
+//	The updated matchType object with the "fuzzy_rewrite" field set to the specified value.
+func (m matchType) FuzzyRewrite(fuzzyRewrite string) matchType {
+	return m.putInTheField("fuzzy_rewrite", fuzzyRewrite)
+}
+
+// FuzzyTranspositions sets the "fuzzy_transpositions" field in the match query.
+//
+// This method configures the match query to allow or disallow transpositions (e.g., swapping two adjacent characters)
+// when performing fuzzy matching. Setting this field to true enables transpositions, which can increase the match rate
+// for terms with common typos or character swaps. It calls putInTheField to add or update the "fuzzy_transpositions" key
+// in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").FuzzyTranspositions(true)
+//	// m now has a "fuzzy_transpositions" field set to true in the match query object.
+//
+// Parameters:
+//   - fuzzyTranspositions: A boolean value indicating whether transpositions should be allowed in fuzzy matching.
+//
+// Returns:
+//
+//	The updated matchType object with the "fuzzy_transpositions" field set to the specified value.
+func (m matchType) FuzzyTranspositions(fuzzyTranspositions bool) matchType {
+	return m.putInTheField("fuzzy_transpositions", fuzzyTranspositions)
+}
+
+// Lenient sets the "lenient" field in the match query.
+//
+// This method configures the match query to use lenient parsing, allowing it to skip errors
+// for data type mismatches. When set to true, documents that contain mismatched data types
+// (e.g., text in a numeric field) will not cause errors and will be ignored instead.
+// It calls putInTheField to add or update the "lenient" key in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").Lenient(true)
+//	// m now has a "lenient" field set to true in the match query object.
+//
+// Parameters:
+//   - lenient: A boolean value indicating whether lenient parsing should be enabled.
+//
+// Returns:
+//
+//	The updated matchType object with the "lenient" field set to the specified value.
+func (m matchType) Lenient(lenient bool) matchType {
+	return m.putInTheField("lenient", lenient)
+}
+
+// MaxExpansions sets the "max_expansions" field in the match query.
+//
+// This method configures the match query to limit the maximum number of terms that can be expanded
+// for multi-term queries, such as those involving fuzzy matching. Higher values allow more terms to
+// be considered, but may impact performance. It calls putInTheField to add or update the "max_expansions"
+// key in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").MaxExpansions(50)
+//	// m now has a "max_expansions" field set to 50 in the match query object.
+//
+// Parameters:
+//   - maxExpansions: An integer representing the maximum number of term expansions to be allowed in the match query.
+//
+// Returns:
+//
+//	The updated matchType object with the "max_expansions" field set to the specified value.
+func (m matchType) MaxExpansions(maxExpansions int) matchType {
+	return m.putInTheField("max_expansions", maxExpansions)
+}
+
+// PrefixLength sets the "prefix_length" field in the match query.
+//
+// This method configures the match query to specify a minimum prefix length for fuzzy matching,
+// which defines the number of initial characters in a term that must match exactly before
+// considering fuzziness. Increasing this value can improve performance by reducing the number
+// of fuzzy matches, but may also limit the flexibility of the query. It calls putInTheField
+// to add or update the "prefix_length" key in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").PrefixLength(2)
+//	// m now has a "prefix_length" field set to 2 in the match query object.
+//
+// Parameters:
+//   - prefixLength: An integer representing the number of initial characters that must match exactly in fuzzy matching.
+//
+// Returns:
+//
+//	The updated matchType object with the "prefix_length" field set to the specified value.
+func (m matchType) PrefixLength(prefixLength int) matchType {
+	return m.putInTheField("prefix_length", prefixLength)
+}
+
+// ZeroTermsQuery sets the "zero_terms_query" field in the match query.
+//
+// This method configures the behavior of the match query when no terms remain after analysis
+// (for example, if all terms are stop words). The specified zero_terms_query value determines
+// how to handle this scenario, with options like "all" to match all documents or "none" to
+// match none. It calls putInTheField to add or update the "zero_terms_query" key in the match query object.
+//
+// Example usage:
+//
+//	m := es.Match("title", "es-query-builder").ZeroTermsQuery(zerotermsquery.All)
+//	// m now has a "zero_terms_query" field set to "all" in the match query object.
+//
+// Parameters:
+//   - zeroTermsQuery: A zerotermsquery.ZeroTermsQuery value that specifies the behavior for zero-term queries.
+//
+// Returns:
+//
+//	The updated matchType object with the "zero_terms_query" field set to the specified value.
+func (m matchType) ZeroTermsQuery(zeroTermsQuery ZeroTermsQuery.ZeroTermsQuery) matchType {
+	return m.putInTheField("zero_terms_query", zeroTermsQuery)
 }

--- a/es/match_query_test.go
+++ b/es/match_query_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Trendyol/es-query-builder/test/assert"
 
 	Operator "github.com/Trendyol/es-query-builder/es/enums/match/operator"
+	ZeroTermsQuery "github.com/Trendyol/es-query-builder/es/enums/match/zero-terms-query"
 )
 
 ////   Match   ////
@@ -25,19 +26,235 @@ func Test_Match_method_should_create_matchType(t *testing.T) {
 	assert.IsTypeString(t, "es.matchType", b)
 }
 
+func Test_Match_should_have_Boost_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.Boost)
+}
+
+func Test_Match_Boost_should_create_json_with_boost_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			Boost(3.14),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"boost\":3.14,\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_Operator_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.Operator)
+}
+
+func Test_Match_Operator_should_create_json_with_operator_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			Operator(Operator.And),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"operator\":\"and\",\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_CutoffFrequency_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.CutoffFrequency)
+}
+
+func Test_Match_CutoffFrequency_should_create_json_with_cutoff_frequency_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			CutoffFrequency(0.0001),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"cutoff_frequency\":0.0001,\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_Fuzziness_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.Fuzziness)
+}
+
+func Test_Match_Fuzziness_should_create_json_with_fuzziness_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			Fuzziness("AUTO"),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"fuzziness\":\"AUTO\",\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_FuzzyRewrite_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.FuzzyRewrite)
+}
+
+func Test_Match_FuzzyRewrite_should_create_json_with_fuzzy_rewrite_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			FuzzyRewrite("constant_score"),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"fuzzy_rewrite\":\"constant_score\",\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_FuzzyTranspositions_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.FuzzyTranspositions)
+}
+
+func Test_Match_FuzzyTranspositions_should_create_json_with_fuzzy_transpositions_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Directory").
+			FuzzyTranspositions(false),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"fuzzy_transpositions\":false,\"query\":\"Directory\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_Lenient_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.Lenient)
+}
+
+func Test_Match_Lenient_should_create_json_with_lenient_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			Lenient(true),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"lenient\":true,\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_MaxExpansions_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.MaxExpansions)
+}
+
+func Test_Match_MaxExpansions_should_create_json_with_max_expansions_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			MaxExpansions(99),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"max_expansions\":99,\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_PrefixLength_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.PrefixLength)
+}
+
+func Test_Match_PrefixLength_should_create_json_with_prefix_length_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			PrefixLength(40),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"prefix_length\":40,\"query\":\"Folder\"}}}}", bodyJSON)
+}
+
+func Test_Match_should_have_ZeroTermsQuery_method(t *testing.T) {
+	// Given
+	term := es.Match("key", "value")
+
+	// When Then
+	assert.NotNil(t, term.ZeroTermsQuery)
+}
+
+func Test_Match_ZeroTermsQuery_should_create_json_with_zero_terms_query_field_inside_match(t *testing.T) {
+	// Given
+	query := es.NewQuery(
+		es.Match("type", "Folder").
+			ZeroTermsQuery(ZeroTermsQuery.All),
+	)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"query\":{\"match\":{\"type\":{\"query\":\"Folder\",\"zero_terms_query\":\"all\"}}}}", bodyJSON)
+}
+
 func Test_Match_should_create_json_with_match_field_inside_query(t *testing.T) {
 	// Given
 	query := es.NewQuery(
 		es.Match("message", "this is a test").
 			Boost(2.14).
-			Operator(Operator.Or),
+			Operator(Operator.Or).
+			CutoffFrequency(0.241).
+			Fuzziness("AUTO").
+			FuzzyRewrite("constant_score").
+			FuzzyTranspositions(true).
+			Lenient(true).
+			MaxExpansions(50).
+			PrefixLength(2).
+			ZeroTermsQuery(ZeroTermsQuery.None),
 	)
 
 	// When Then
 	assert.NotNil(t, query)
 	bodyJSON := assert.MarshalWithoutError(t, query)
 	// nolint:golint,lll
-	assert.Equal(t, "{\"query\":{\"match\":{\"message\":{\"boost\":2.14,\"operator\":\"or\",\"query\":\"this is a test\"}}}}", bodyJSON)
+	assert.Equal(t, "{\"query\":{\"match\":{\"message\":{\"boost\":2.14,\"cutoff_frequency\":0.241,\"fuzziness\":\"AUTO\",\"fuzzy_rewrite\":\"constant_score\",\"fuzzy_transpositions\":true,\"lenient\":true,\"max_expansions\":50,\"operator\":\"or\",\"prefix_length\":2,\"query\":\"this is a test\",\"zero_terms_query\":\"none\"}}}}", bodyJSON)
 }
-
-// TODO: write parameter test

--- a/es/match_query_test.go
+++ b/es/match_query_test.go
@@ -39,3 +39,5 @@ func Test_Match_should_create_json_with_match_field_inside_query(t *testing.T) {
 	// nolint:golint,lll
 	assert.Equal(t, "{\"query\":{\"match\":{\"message\":{\"boost\":2.14,\"operator\":\"or\",\"query\":\"this is a test\"}}}}", bodyJSON)
 }
+
+// TODO: write parameter test


### PR DESCRIPTION
Add missing parameters of match query

- cutoff_frequency
- fuzziness
- fuzzy_rewrite
- fuzzy_transpositions
- lenient
- max_expansions
- prefix_length
- zero_terms_query