### PR TITLE
Add highlight query support

### DIFF
--- a/es/base_query.go
+++ b/es/base_query.go
@@ -218,6 +218,34 @@ func (o Object) Sort(sorts ...sortType) Object {
 	return o
 }
 
+// Highlight sets the "highlight" parameter in an es.Object.
+//
+// This method allows you to specify highlighting configuration for the search query.
+// Highlighting enables you to get highlighted snippets from one or more fields in your
+// search results so you can show users where the query matches are.
+//
+// Example usage:
+//
+//	query := es.NewQuery(es.MatchAll()).
+//		Highlight(
+//			es.Highlight().
+//				PreTags("<em>").
+//				PostTags("</em>").
+//				Field(es.HighlightField("title")),
+//		)
+//	// query now includes a "highlight" parameter with the specified configuration.
+//
+// Parameters:
+//   - highlight: An es.highlightType object representing the highlight configuration.
+//
+// Returns:
+//
+//	The updated es.Object with the "highlight" parameter set.
+func (o Object) Highlight(highlight highlightType) Object {
+	o["highlight"] = highlight
+	return o
+}
+
 // Aggs adds one or more es.aggsType objects to an es.Object.
 //
 // This method allows you to specify multiple aggregation criteria for the search query.

--- a/es/enums/boundary-scanner/boundary_scanner.go
+++ b/es/enums/boundary-scanner/boundary_scanner.go
@@ -1,0 +1,33 @@
+package boundaryscanner
+
+// BoundaryScanner represents the different boundary scanner types for highlighting in Elasticsearch.
+//
+// BoundaryScanner is a string type used to specify how highlighted fragments are bounded.
+// It determines the strategy for finding the boundaries of highlighted snippets.
+//
+// Example usage:
+//
+//	var bs BoundaryScanner = Sentence
+//
+//	// Use bs in a highlight configuration
+//
+// Constants:
+//   - Chars: The chars boundary scanner breaks highlighted fragments at characters specified by boundary_chars.
+//   - Sentence: The sentence boundary scanner breaks highlighted fragments at the next sentence boundary.
+//   - Word: The word boundary scanner breaks highlighted fragments at the next word boundary.
+type BoundaryScanner string
+
+const (
+	// Chars indicates that the boundary scanner should break at specified boundary characters.
+	Chars BoundaryScanner = "chars"
+
+	// Sentence indicates that the boundary scanner should break at sentence boundaries.
+	Sentence BoundaryScanner = "sentence"
+
+	// Word indicates that the boundary scanner should break at word boundaries.
+	Word BoundaryScanner = "word"
+)
+
+func (boundaryScanner BoundaryScanner) String() string {
+	return string(boundaryScanner)
+}

--- a/es/enums/boundary-scanner/boundary_scanner_test.go
+++ b/es/enums/boundary-scanner/boundary_scanner_test.go
@@ -1,0 +1,26 @@
+package boundaryscanner_test
+
+import (
+	"testing"
+
+	BoundaryScanner "github.com/Trendyol/es-query-builder/es/enums/boundary-scanner"
+
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+func Test_BoundaryScannerString(t *testing.T) {
+	tests := []struct {
+		boundaryScanner BoundaryScanner.BoundaryScanner
+		result          string
+	}{
+		{BoundaryScanner.Chars, "chars"},
+		{BoundaryScanner.Sentence, "sentence"},
+		{BoundaryScanner.Word, "word"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.result, func(t *testing.T) {
+			assert.Equal(t, test.result, test.boundaryScanner.String())
+		})
+	}
+}

--- a/es/enums/fragmenter/fragmenter.go
+++ b/es/enums/fragmenter/fragmenter.go
@@ -1,0 +1,30 @@
+package fragmenter
+
+// Fragmenter represents the different fragmenter types for highlighting in Elasticsearch.
+//
+// Fragmenter is a string type used to specify how text should be broken up into
+// highlight fragments. It determines the strategy for creating text fragments
+// that contain highlighted terms.
+//
+// Example usage:
+//
+//	var f Fragmenter = Span
+//
+//	// Use f in a highlight configuration
+//
+// Constants:
+//   - Simple: The simple fragmenter breaks text into same-sized fragments.
+//   - Span: The span fragmenter breaks text into same-sized fragments, but tries to avoid breaking up highlighted terms.
+type Fragmenter string
+
+const (
+	// Simple indicates that text should be broken into same-sized fragments.
+	Simple Fragmenter = "simple"
+
+	// Span indicates that text should be broken into same-sized fragments while trying to avoid breaking highlighted terms.
+	Span Fragmenter = "span"
+)
+
+func (fragmenter Fragmenter) String() string {
+	return string(fragmenter)
+}

--- a/es/enums/fragmenter/fragmenter_test.go
+++ b/es/enums/fragmenter/fragmenter_test.go
@@ -1,0 +1,25 @@
+package fragmenter_test
+
+import (
+	"testing"
+
+	Fragmenter "github.com/Trendyol/es-query-builder/es/enums/fragmenter"
+
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+func Test_FragmenterString(t *testing.T) {
+	tests := []struct {
+		fragmenter Fragmenter.Fragmenter
+		result     string
+	}{
+		{Fragmenter.Simple, "simple"},
+		{Fragmenter.Span, "span"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.result, func(t *testing.T) {
+			assert.Equal(t, test.result, test.fragmenter.String())
+		})
+	}
+}

--- a/es/enums/highlighter-type/highlighter_type.go
+++ b/es/enums/highlighter-type/highlighter_type.go
@@ -1,0 +1,34 @@
+package highlightertype
+
+// HighlighterType represents the different highlighter types available in Elasticsearch.
+//
+// HighlighterType is a string type used to specify which highlighter implementation
+// to use for highlighting search results. Elasticsearch provides three highlighter
+// implementations: unified, plain, and fvh (Fast Vector Highlighter).
+//
+// Example usage:
+//
+//	var ht HighlighterType = Unified
+//
+//	// Use ht in a highlight configuration
+//
+// Constants:
+//   - Unified: The unified highlighter uses the Lucene Unified Highlighter (default).
+//   - Plain: The plain highlighter uses the standard Lucene highlighter.
+//   - Fvh: The fvh (Fast Vector Highlighter) highlighter uses the Lucene Fast Vector Highlighter.
+type HighlighterType string
+
+const (
+	// Unified indicates the unified highlighter, which is the default highlighter in Elasticsearch.
+	Unified HighlighterType = "unified"
+
+	// Plain indicates the plain highlighter, which uses the standard Lucene highlighter.
+	Plain HighlighterType = "plain"
+
+	// Fvh indicates the Fast Vector Highlighter, which requires term_vector set to with_positions_offsets.
+	Fvh HighlighterType = "fvh"
+)
+
+func (highlighterType HighlighterType) String() string {
+	return string(highlighterType)
+}

--- a/es/enums/highlighter-type/highlighter_type_test.go
+++ b/es/enums/highlighter-type/highlighter_type_test.go
@@ -1,0 +1,26 @@
+package highlightertype_test
+
+import (
+	"testing"
+
+	HighlighterType "github.com/Trendyol/es-query-builder/es/enums/highlighter-type"
+
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+func Test_HighlighterTypeString(t *testing.T) {
+	tests := []struct {
+		highlighterType HighlighterType.HighlighterType
+		result          string
+	}{
+		{HighlighterType.Unified, "unified"},
+		{HighlighterType.Plain, "plain"},
+		{HighlighterType.Fvh, "fvh"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.result, func(t *testing.T) {
+			assert.Equal(t, test.result, test.highlighterType.String())
+		})
+	}
+}

--- a/es/highlight.go
+++ b/es/highlight.go
@@ -1,0 +1,722 @@
+package es
+
+import (
+	BoundaryScanner "github.com/Trendyol/es-query-builder/es/enums/boundary-scanner"
+	Fragmenter "github.com/Trendyol/es-query-builder/es/enums/fragmenter"
+	HighlighterType "github.com/Trendyol/es-query-builder/es/enums/highlighter-type"
+)
+
+type highlightType Object
+
+type highlightFieldType Object
+
+// Highlight creates a new es.highlightType object.
+//
+// This function initializes a highlight configuration object that can be used
+// to configure how search results are highlighted. The highlight object is
+// typically added to a query using the Highlight method on es.Object.
+//
+// Example usage:
+//
+//	h := es.Highlight().
+//		PreTags("<em>").
+//		PostTags("</em>").
+//		Field(es.HighlightField("title"))
+//	query := es.NewQuery(es.MatchAll()).Highlight(h)
+//
+// Returns:
+//
+//	An es.highlightType object ready for further configuration.
+func Highlight() highlightType {
+	return highlightType{}
+}
+
+// PreTags sets the "pre_tags" parameter in an es.highlightType.
+//
+// This method specifies the HTML tags or strings to insert before the highlighted text.
+// Multiple tags can be provided for use with different highlight levels.
+//
+// Example usage:
+//
+//	h := es.Highlight().PreTags("<em>", "<strong>")
+//	// h now includes a "pre_tags" parameter with the specified tags.
+//
+// Parameters:
+//   - tags: A variadic list of strings representing the pre-tags.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "pre_tags" parameter set.
+func (h highlightType) PreTags(tags ...string) highlightType {
+	h["pre_tags"] = tags
+	return h
+}
+
+// PostTags sets the "post_tags" parameter in an es.highlightType.
+//
+// This method specifies the HTML tags or strings to insert after the highlighted text.
+// Multiple tags can be provided for use with different highlight levels.
+//
+// Example usage:
+//
+//	h := es.Highlight().PostTags("</em>", "</strong>")
+//	// h now includes a "post_tags" parameter with the specified tags.
+//
+// Parameters:
+//   - tags: A variadic list of strings representing the post-tags.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "post_tags" parameter set.
+func (h highlightType) PostTags(tags ...string) highlightType {
+	h["post_tags"] = tags
+	return h
+}
+
+// Field adds a highlight field configuration to the es.highlightType.
+//
+// This method adds one or more field configurations to the "fields" object in the
+// highlight configuration. Each field can have its own highlight settings that
+// override the global highlight settings.
+//
+// Example usage:
+//
+//	h := es.Highlight().
+//		Field(es.HighlightField("title").NumberOfFragments(0)).
+//		Field(es.HighlightField("content").FragmentSize(150).NumberOfFragments(3))
+//	// h now includes a "fields" object with configurations for "title" and "content".
+//
+// Parameters:
+//   - fields: A variadic list of es.highlightFieldType objects.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the field configurations added.
+func (h highlightType) Field(fields ...highlightFieldType) highlightType {
+	highlightFields, ok := h["fields"].(Object)
+	if !ok {
+		highlightFields = Object{}
+	}
+	for _, field := range fields {
+		for key, value := range field {
+			highlightFields[key] = value
+		}
+	}
+	h["fields"] = highlightFields
+	return h
+}
+
+// Type sets the "type" parameter in an es.highlightType.
+//
+// This method specifies which highlighter implementation to use. Elasticsearch
+// provides three highlighter implementations: unified, plain, and fvh.
+//
+// Example usage:
+//
+//	h := es.Highlight().Type(HighlighterType.Unified)
+//	// h now includes a "type" parameter set to "unified".
+//
+// Parameters:
+//   - highlighterType: A HighlighterType.HighlighterType value representing the highlighter type.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "type" parameter set.
+func (h highlightType) Type(highlighterType HighlighterType.HighlighterType) highlightType {
+	h["type"] = highlighterType
+	return h
+}
+
+// Order sets the "order" parameter in an es.highlightType.
+//
+// This method specifies the order in which highlighted fragments are sorted.
+// Setting it to "score" sorts highlighted fragments by relevance score.
+//
+// Example usage:
+//
+//	h := es.Highlight().Order("score")
+//	// h now includes an "order" parameter set to "score".
+//
+// Parameters:
+//   - order: A string representing the order for highlighted fragments.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "order" parameter set.
+func (h highlightType) Order(order string) highlightType {
+	h["order"] = order
+	return h
+}
+
+// Encoder sets the "encoder" parameter in an es.highlightType.
+//
+// This method specifies how the highlighted text should be encoded. The "default"
+// encoder provides no encoding, while "html" encodes the highlighted text as HTML.
+//
+// Example usage:
+//
+//	h := es.Highlight().Encoder("html")
+//	// h now includes an "encoder" parameter set to "html".
+//
+// Parameters:
+//   - encoder: A string representing the encoder type ("default" or "html").
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "encoder" parameter set.
+func (h highlightType) Encoder(encoder string) highlightType {
+	h["encoder"] = encoder
+	return h
+}
+
+// RequireFieldMatch sets the "require_field_match" parameter in an es.highlightType.
+//
+// This method specifies whether only fields that match the query should be highlighted.
+// When set to false, all fields will be highlighted regardless of whether they contributed
+// to the query match.
+//
+// Example usage:
+//
+//	h := es.Highlight().RequireFieldMatch(false)
+//	// h now includes a "require_field_match" parameter set to false.
+//
+// Parameters:
+//   - requireFieldMatch: A boolean indicating whether to require field match for highlighting.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "require_field_match" parameter set.
+func (h highlightType) RequireFieldMatch(requireFieldMatch bool) highlightType {
+	h["require_field_match"] = requireFieldMatch
+	return h
+}
+
+// FragmentSize sets the "fragment_size" parameter in an es.highlightType.
+//
+// This method specifies the size of the highlighted fragment in characters.
+// The default value is 100.
+//
+// Example usage:
+//
+//	h := es.Highlight().FragmentSize(150)
+//	// h now includes a "fragment_size" parameter set to 150.
+//
+// Parameters:
+//   - fragmentSize: An integer representing the fragment size in characters.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "fragment_size" parameter set.
+func (h highlightType) FragmentSize(fragmentSize int) highlightType {
+	h["fragment_size"] = fragmentSize
+	return h
+}
+
+// NumberOfFragments sets the "number_of_fragments" parameter in an es.highlightType.
+//
+// This method specifies the maximum number of fragments to return. If set to 0,
+// the entire field content is returned as a single fragment.
+//
+// Example usage:
+//
+//	h := es.Highlight().NumberOfFragments(5)
+//	// h now includes a "number_of_fragments" parameter set to 5.
+//
+// Parameters:
+//   - numberOfFragments: An integer representing the maximum number of fragments.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "number_of_fragments" parameter set.
+func (h highlightType) NumberOfFragments(numberOfFragments int) highlightType {
+	h["number_of_fragments"] = numberOfFragments
+	return h
+}
+
+// NoMatchSize sets the "no_match_size" parameter in an es.highlightType.
+//
+// This method specifies the amount of text to return from the beginning of the field
+// if there are no matching fragments to highlight. The default value is 0, which means
+// nothing is returned.
+//
+// Example usage:
+//
+//	h := es.Highlight().NoMatchSize(150)
+//	// h now includes a "no_match_size" parameter set to 150.
+//
+// Parameters:
+//   - noMatchSize: An integer representing the number of characters to return when no match is found.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "no_match_size" parameter set.
+func (h highlightType) NoMatchSize(noMatchSize int) highlightType {
+	h["no_match_size"] = noMatchSize
+	return h
+}
+
+// BoundaryScanner sets the "boundary_scanner" parameter in an es.highlightType.
+//
+// This method specifies how highlighted fragments are bounded. The boundary scanner
+// determines the strategy for finding the boundaries of highlighted snippets.
+//
+// Example usage:
+//
+//	h := es.Highlight().BoundaryScanner(BoundaryScanner.Sentence)
+//	// h now includes a "boundary_scanner" parameter set to "sentence".
+//
+// Parameters:
+//   - boundaryScanner: A BoundaryScanner.BoundaryScanner value representing the boundary scanner type.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "boundary_scanner" parameter set.
+func (h highlightType) BoundaryScanner(boundaryScanner BoundaryScanner.BoundaryScanner) highlightType {
+	h["boundary_scanner"] = boundaryScanner
+	return h
+}
+
+// BoundaryChars sets the "boundary_chars" parameter in an es.highlightType.
+//
+// This method specifies a string containing each boundary character for the chars
+// boundary scanner. The default value is ".,!? \t\n".
+//
+// Example usage:
+//
+//	h := es.Highlight().BoundaryChars(".,!? \t\n")
+//	// h now includes a "boundary_chars" parameter with the specified characters.
+//
+// Parameters:
+//   - boundaryChars: A string containing the boundary characters.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "boundary_chars" parameter set.
+func (h highlightType) BoundaryChars(boundaryChars string) highlightType {
+	h["boundary_chars"] = boundaryChars
+	return h
+}
+
+// BoundaryMaxScan sets the "boundary_max_scan" parameter in an es.highlightType.
+//
+// This method specifies how far to scan for boundary characters when using the chars
+// boundary scanner. The default value is 20.
+//
+// Example usage:
+//
+//	h := es.Highlight().BoundaryMaxScan(20)
+//	// h now includes a "boundary_max_scan" parameter set to 20.
+//
+// Parameters:
+//   - boundaryMaxScan: An integer representing the maximum number of characters to scan.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "boundary_max_scan" parameter set.
+func (h highlightType) BoundaryMaxScan(boundaryMaxScan int) highlightType {
+	h["boundary_max_scan"] = boundaryMaxScan
+	return h
+}
+
+// BoundaryScannerLocale sets the "boundary_scanner_locale" parameter in an es.highlightType.
+//
+// This method specifies the locale to use for the sentence and word boundary scanners.
+// This allows proper handling of word and sentence boundaries for different languages.
+//
+// Example usage:
+//
+//	h := es.Highlight().BoundaryScannerLocale("en-US")
+//	// h now includes a "boundary_scanner_locale" parameter set to "en-US".
+//
+// Parameters:
+//   - locale: A string representing the locale (e.g., "en-US").
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "boundary_scanner_locale" parameter set.
+func (h highlightType) BoundaryScannerLocale(locale string) highlightType {
+	h["boundary_scanner_locale"] = locale
+	return h
+}
+
+// Fragmenter sets the "fragmenter" parameter in an es.highlightType.
+//
+// This method specifies how text should be broken up into highlight fragments.
+// The simple fragmenter breaks text into same-sized fragments, while the span
+// fragmenter tries to avoid breaking up highlighted terms.
+//
+// Example usage:
+//
+//	h := es.Highlight().Fragmenter(Fragmenter.Span)
+//	// h now includes a "fragmenter" parameter set to "span".
+//
+// Parameters:
+//   - fragmenter: A Fragmenter.Fragmenter value representing the fragmenter type.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "fragmenter" parameter set.
+func (h highlightType) Fragmenter(fragmenter Fragmenter.Fragmenter) highlightType {
+	h["fragmenter"] = fragmenter
+	return h
+}
+
+// FragmentOffset sets the "fragment_offset" parameter in an es.highlightType.
+//
+// This method specifies the margin from which to start highlighting. This is only
+// valid when using the fvh highlighter.
+//
+// Example usage:
+//
+//	h := es.Highlight().FragmentOffset(10)
+//	// h now includes a "fragment_offset" parameter set to 10.
+//
+// Parameters:
+//   - fragmentOffset: An integer representing the fragment offset.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "fragment_offset" parameter set.
+func (h highlightType) FragmentOffset(fragmentOffset int) highlightType {
+	h["fragment_offset"] = fragmentOffset
+	return h
+}
+
+// MaxFragmentLength sets the "max_fragment_length" parameter in an es.highlightType.
+//
+// This method specifies the maximum length of a fragment in characters. This is only
+// valid when using the unified highlighter.
+//
+// Example usage:
+//
+//	h := es.Highlight().MaxFragmentLength(200)
+//	// h now includes a "max_fragment_length" parameter set to 200.
+//
+// Parameters:
+//   - maxFragmentLength: An integer representing the maximum fragment length.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "max_fragment_length" parameter set.
+func (h highlightType) MaxFragmentLength(maxFragmentLength int) highlightType {
+	h["max_fragment_length"] = maxFragmentLength
+	return h
+}
+
+// MaxAnalyzedOffset sets the "max_analyzed_offset" parameter in an es.highlightType.
+//
+// This method specifies the maximum number of characters that will be analyzed for
+// highlighting. The remaining text will not be processed. This setting is particularly
+// useful for large text fields to avoid excessive memory usage.
+//
+// Example usage:
+//
+//	h := es.Highlight().MaxAnalyzedOffset(1000000)
+//	// h now includes a "max_analyzed_offset" parameter set to 1000000.
+//
+// Parameters:
+//   - maxAnalyzedOffset: An integer representing the maximum analyzed offset.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "max_analyzed_offset" parameter set.
+func (h highlightType) MaxAnalyzedOffset(maxAnalyzedOffset int) highlightType {
+	h["max_analyzed_offset"] = maxAnalyzedOffset
+	return h
+}
+
+// HighlightQuery sets the "highlight_query" parameter in an es.highlightType.
+//
+// This method specifies an additional query to use for highlighting. This allows
+// highlighting based on a different query than the main search query.
+//
+// Example usage:
+//
+//	h := es.Highlight().HighlightQuery(es.Match("content", "elasticsearch"))
+//	// h now includes a "highlight_query" parameter with the specified query.
+//
+// Parameters:
+//   - query: An object representing the highlight query. It can be of any type.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "highlight_query" parameter set.
+func (h highlightType) HighlightQuery(query any) highlightType {
+	if field, ok := correctType(query); ok {
+		h["highlight_query"] = field
+	}
+	return h
+}
+
+// TagsSchema sets the "tags_schema" parameter in an es.highlightType.
+//
+// This method specifies the tags schema to use for highlighting. Setting it to "styled"
+// uses a built-in set of pre/post tags.
+//
+// Example usage:
+//
+//	h := es.Highlight().TagsSchema("styled")
+//	// h now includes a "tags_schema" parameter set to "styled".
+//
+// Parameters:
+//   - tagsSchema: A string representing the tags schema.
+//
+// Returns:
+//
+//	The updated es.highlightType object with the "tags_schema" parameter set.
+func (h highlightType) TagsSchema(tagsSchema string) highlightType {
+	h["tags_schema"] = tagsSchema
+	return h
+}
+
+// HighlightField creates a new es.highlightFieldType object with the specified field name.
+//
+// This function initializes a highlight field configuration for use in the "fields" object
+// of a highlight configuration. Each field can have its own highlight settings that
+// override the global highlight settings.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("title")
+//	// hf now contains a highlight field configuration for the "title" field.
+//
+// Parameters:
+//   - field: A string representing the field name to highlight.
+//
+// Returns:
+//
+//	An es.highlightFieldType object with the specified field.
+func HighlightField(field string) highlightFieldType {
+	return highlightFieldType{
+		field: Object{},
+	}
+}
+
+// PreTags sets the "pre_tags" parameter in an es.highlightFieldType.
+//
+// This method specifies the HTML tags or strings to insert before the highlighted text
+// for this specific field, overriding the global pre_tags setting.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("title").PreTags("<b>")
+//	// hf now includes a "pre_tags" parameter for the "title" field.
+//
+// Parameters:
+//   - tags: A variadic list of strings representing the pre-tags.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "pre_tags" parameter set.
+func (hf highlightFieldType) PreTags(tags ...string) highlightFieldType {
+	return hf.putInTheField("pre_tags", tags)
+}
+
+// PostTags sets the "post_tags" parameter in an es.highlightFieldType.
+//
+// This method specifies the HTML tags or strings to insert after the highlighted text
+// for this specific field, overriding the global post_tags setting.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("title").PostTags("</b>")
+//	// hf now includes a "post_tags" parameter for the "title" field.
+//
+// Parameters:
+//   - tags: A variadic list of strings representing the post-tags.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "post_tags" parameter set.
+func (hf highlightFieldType) PostTags(tags ...string) highlightFieldType {
+	return hf.putInTheField("post_tags", tags)
+}
+
+// Type sets the "type" parameter in an es.highlightFieldType.
+//
+// This method specifies which highlighter implementation to use for this specific field,
+// overriding the global type setting.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("title").Type(HighlighterType.Plain)
+//	// hf now includes a "type" parameter for the "title" field.
+//
+// Parameters:
+//   - highlighterType: A HighlighterType.HighlighterType value representing the highlighter type.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "type" parameter set.
+func (hf highlightFieldType) Type(highlighterType HighlighterType.HighlighterType) highlightFieldType {
+	return hf.putInTheField("type", highlighterType)
+}
+
+// FragmentSize sets the "fragment_size" parameter in an es.highlightFieldType.
+//
+// This method specifies the size of the highlighted fragment in characters for this
+// specific field, overriding the global fragment_size setting.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("content").FragmentSize(150)
+//	// hf now includes a "fragment_size" parameter for the "content" field.
+//
+// Parameters:
+//   - fragmentSize: An integer representing the fragment size in characters.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "fragment_size" parameter set.
+func (hf highlightFieldType) FragmentSize(fragmentSize int) highlightFieldType {
+	return hf.putInTheField("fragment_size", fragmentSize)
+}
+
+// NumberOfFragments sets the "number_of_fragments" parameter in an es.highlightFieldType.
+//
+// This method specifies the maximum number of fragments to return for this specific field,
+// overriding the global number_of_fragments setting. If set to 0, the entire field content
+// is returned as a single fragment.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("title").NumberOfFragments(0)
+//	// hf now includes a "number_of_fragments" parameter for the "title" field.
+//
+// Parameters:
+//   - numberOfFragments: An integer representing the maximum number of fragments.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "number_of_fragments" parameter set.
+func (hf highlightFieldType) NumberOfFragments(numberOfFragments int) highlightFieldType {
+	return hf.putInTheField("number_of_fragments", numberOfFragments)
+}
+
+// NoMatchSize sets the "no_match_size" parameter in an es.highlightFieldType.
+//
+// This method specifies the amount of text to return from the beginning of the field
+// if there are no matching fragments for this specific field.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("content").NoMatchSize(150)
+//	// hf now includes a "no_match_size" parameter for the "content" field.
+//
+// Parameters:
+//   - noMatchSize: An integer representing the number of characters to return when no match is found.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "no_match_size" parameter set.
+func (hf highlightFieldType) NoMatchSize(noMatchSize int) highlightFieldType {
+	return hf.putInTheField("no_match_size", noMatchSize)
+}
+
+// Order sets the "order" parameter in an es.highlightFieldType.
+//
+// This method specifies the order in which highlighted fragments are sorted for this
+// specific field, overriding the global order setting.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("content").Order("score")
+//	// hf now includes an "order" parameter for the "content" field.
+//
+// Parameters:
+//   - order: A string representing the order for highlighted fragments.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "order" parameter set.
+func (hf highlightFieldType) Order(order string) highlightFieldType {
+	return hf.putInTheField("order", order)
+}
+
+// HighlightQuery sets the "highlight_query" parameter in an es.highlightFieldType.
+//
+// This method specifies an additional query to use for highlighting this specific field.
+// This allows highlighting based on a different query than the main search query.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("content").HighlightQuery(es.Match("content", "elasticsearch"))
+//	// hf now includes a "highlight_query" parameter for the "content" field.
+//
+// Parameters:
+//   - query: An object representing the highlight query. It can be of any type.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "highlight_query" parameter set.
+func (hf highlightFieldType) HighlightQuery(query any) highlightFieldType {
+	if field, ok := correctType(query); ok {
+		return hf.putInTheField("highlight_query", field)
+	}
+	return hf
+}
+
+// RequireFieldMatch sets the "require_field_match" parameter in an es.highlightFieldType.
+//
+// This method specifies whether only this field should be highlighted if it matches the query,
+// overriding the global require_field_match setting.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("content").RequireFieldMatch(false)
+//	// hf now includes a "require_field_match" parameter for the "content" field.
+//
+// Parameters:
+//   - requireFieldMatch: A boolean indicating whether to require field match for highlighting.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "require_field_match" parameter set.
+func (hf highlightFieldType) RequireFieldMatch(requireFieldMatch bool) highlightFieldType {
+	return hf.putInTheField("require_field_match", requireFieldMatch)
+}
+
+// Fragmenter sets the "fragmenter" parameter in an es.highlightFieldType.
+//
+// This method specifies how text should be broken up into highlight fragments for this
+// specific field, overriding the global fragmenter setting.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("content").Fragmenter(Fragmenter.Span)
+//	// hf now includes a "fragmenter" parameter for the "content" field.
+//
+// Parameters:
+//   - fragmenter: A Fragmenter.Fragmenter value representing the fragmenter type.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "fragmenter" parameter set.
+func (hf highlightFieldType) Fragmenter(fragmenter Fragmenter.Fragmenter) highlightFieldType {
+	return hf.putInTheField("fragmenter", fragmenter)
+}
+
+// MatchedFields sets the "matched_fields" parameter in an es.highlightFieldType.
+//
+// This method specifies the fields to combine matches from for highlighting. This is
+// useful when using the fvh highlighter to highlight a field based on matches from
+// multiple fields.
+//
+// Example usage:
+//
+//	hf := es.HighlightField("content").MatchedFields("content", "content.plain")
+//	// hf now includes a "matched_fields" parameter for the "content" field.
+//
+// Parameters:
+//   - fields: A variadic list of strings representing the fields to combine matches from.
+//
+// Returns:
+//
+//	The updated es.highlightFieldType object with the "matched_fields" parameter set.
+func (hf highlightFieldType) MatchedFields(fields ...string) highlightFieldType {
+	return hf.putInTheField("matched_fields", fields)
+}
+
+func (hf highlightFieldType) putInTheField(key string, value any) highlightFieldType {
+	return genericPutInTheFieldOfFirstObject(hf, key, value)
+}

--- a/es/highlight_test.go
+++ b/es/highlight_test.go
@@ -775,6 +775,17 @@ func Test_HighlightField_should_have_HighlightQuery_method(t *testing.T) {
 	assert.NotNil(t, hf.HighlightQuery)
 }
 
+func Test_HighlightField_HighlightQuery_should_not_set_highlight_query_when_query_is_nil(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").HighlightQuery(nil)
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{}}", bodyJSON)
+}
+
 func Test_HighlightField_HighlightQuery_should_create_json_with_highlight_query_field(t *testing.T) {
 	t.Parallel()
 	// Given

--- a/es/highlight_test.go
+++ b/es/highlight_test.go
@@ -1,0 +1,907 @@
+package es_test
+
+import (
+	"testing"
+
+	BoundaryScanner "github.com/Trendyol/es-query-builder/es/enums/boundary-scanner"
+	Fragmenter "github.com/Trendyol/es-query-builder/es/enums/fragmenter"
+	HighlighterType "github.com/Trendyol/es-query-builder/es/enums/highlighter-type"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   Highlight   ////
+
+func Test_Highlight_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.Highlight)
+}
+
+func Test_Highlight_method_should_create_highlightType(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// Then
+	assert.NotNil(t, h)
+	assert.IsTypeString(t, "es.highlightType", h)
+}
+
+func Test_Highlight_should_create_json_with_highlight_field_inside_query(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight())
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   Object Highlight method   ////
+
+func Test_Object_should_have_Highlight_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	b := es.NewQuery(nil)
+
+	// When Then
+	assert.NotNil(t, b.Highlight)
+}
+
+////   PreTags   ////
+
+func Test_Highlight_should_have_PreTags_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.PreTags)
+}
+
+func Test_Highlight_PreTags_should_create_json_with_pre_tags_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().PreTags("<em>"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"pre_tags\":[\"\\u003cem\\u003e\"]},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+func Test_Highlight_PreTags_should_create_json_with_multiple_pre_tags(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().PreTags("<em>", "<strong>"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"pre_tags\":[\"\\u003cem\\u003e\",\"\\u003cstrong\\u003e\"]},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   PostTags   ////
+
+func Test_Highlight_should_have_PostTags_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.PostTags)
+}
+
+func Test_Highlight_PostTags_should_create_json_with_post_tags_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().PostTags("</em>"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"post_tags\":[\"\\u003c/em\\u003e\"]},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   Field   ////
+
+func Test_Highlight_should_have_Field_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.Field)
+}
+
+func Test_Highlight_Field_should_create_json_with_fields_object(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(
+			es.Highlight().
+				Field(es.HighlightField("title")),
+		)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"fields\":{\"title\":{}}},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+func Test_Highlight_Field_should_create_json_with_multiple_fields(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(
+			es.Highlight().
+				Field(es.HighlightField("title")).
+				Field(es.HighlightField("content")),
+		)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"fields\":{\"content\":{},\"title\":{}}},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+func Test_Highlight_Field_should_create_json_with_multiple_fields_in_single_call(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(
+			es.Highlight().
+				Field(
+					es.HighlightField("title"),
+					es.HighlightField("content"),
+				),
+		)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"fields\":{\"content\":{},\"title\":{}}},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   Type   ////
+
+func Test_Highlight_should_have_Type_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.Type)
+}
+
+func Test_Highlight_Type_should_create_json_with_type_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().Type(HighlighterType.Unified))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"type\":\"unified\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   Order   ////
+
+func Test_Highlight_should_have_Order_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.Order)
+}
+
+func Test_Highlight_Order_should_create_json_with_order_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().Order("score"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"order\":\"score\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   Encoder   ////
+
+func Test_Highlight_should_have_Encoder_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.Encoder)
+}
+
+func Test_Highlight_Encoder_should_create_json_with_encoder_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().Encoder("html"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"encoder\":\"html\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   RequireFieldMatch   ////
+
+func Test_Highlight_should_have_RequireFieldMatch_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.RequireFieldMatch)
+}
+
+func Test_Highlight_RequireFieldMatch_should_create_json_with_require_field_match_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().RequireFieldMatch(false))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"require_field_match\":false},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   FragmentSize   ////
+
+func Test_Highlight_should_have_FragmentSize_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.FragmentSize)
+}
+
+func Test_Highlight_FragmentSize_should_create_json_with_fragment_size_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().FragmentSize(150))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"fragment_size\":150},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   NumberOfFragments   ////
+
+func Test_Highlight_should_have_NumberOfFragments_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.NumberOfFragments)
+}
+
+func Test_Highlight_NumberOfFragments_should_create_json_with_number_of_fragments_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().NumberOfFragments(5))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"number_of_fragments\":5},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   NoMatchSize   ////
+
+func Test_Highlight_should_have_NoMatchSize_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.NoMatchSize)
+}
+
+func Test_Highlight_NoMatchSize_should_create_json_with_no_match_size_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().NoMatchSize(150))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"no_match_size\":150},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   BoundaryScanner   ////
+
+func Test_Highlight_should_have_BoundaryScanner_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.BoundaryScanner)
+}
+
+func Test_Highlight_BoundaryScanner_should_create_json_with_boundary_scanner_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().BoundaryScanner(BoundaryScanner.Sentence))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"boundary_scanner\":\"sentence\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   BoundaryChars   ////
+
+func Test_Highlight_should_have_BoundaryChars_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.BoundaryChars)
+}
+
+func Test_Highlight_BoundaryChars_should_create_json_with_boundary_chars_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().BoundaryChars(".,!?"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"boundary_chars\":\".,!?\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   BoundaryMaxScan   ////
+
+func Test_Highlight_should_have_BoundaryMaxScan_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.BoundaryMaxScan)
+}
+
+func Test_Highlight_BoundaryMaxScan_should_create_json_with_boundary_max_scan_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().BoundaryMaxScan(20))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"boundary_max_scan\":20},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   BoundaryScannerLocale   ////
+
+func Test_Highlight_should_have_BoundaryScannerLocale_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.BoundaryScannerLocale)
+}
+
+func Test_Highlight_BoundaryScannerLocale_should_create_json_with_boundary_scanner_locale_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().BoundaryScannerLocale("en-US"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"boundary_scanner_locale\":\"en-US\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   Fragmenter   ////
+
+func Test_Highlight_should_have_Fragmenter_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.Fragmenter)
+}
+
+func Test_Highlight_Fragmenter_should_create_json_with_fragmenter_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().Fragmenter(Fragmenter.Span))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"fragmenter\":\"span\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   FragmentOffset   ////
+
+func Test_Highlight_should_have_FragmentOffset_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.FragmentOffset)
+}
+
+func Test_Highlight_FragmentOffset_should_create_json_with_fragment_offset_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().FragmentOffset(10))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"fragment_offset\":10},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   MaxFragmentLength   ////
+
+func Test_Highlight_should_have_MaxFragmentLength_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.MaxFragmentLength)
+}
+
+func Test_Highlight_MaxFragmentLength_should_create_json_with_max_fragment_length_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().MaxFragmentLength(200))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"max_fragment_length\":200},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   MaxAnalyzedOffset   ////
+
+func Test_Highlight_should_have_MaxAnalyzedOffset_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.MaxAnalyzedOffset)
+}
+
+func Test_Highlight_MaxAnalyzedOffset_should_create_json_with_max_analyzed_offset_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().MaxAnalyzedOffset(1000000))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"max_analyzed_offset\":1000000},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   HighlightQuery   ////
+
+func Test_Highlight_should_have_HighlightQuery_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.HighlightQuery)
+}
+
+func Test_Highlight_HighlightQuery_should_create_json_with_highlight_query_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(
+			es.Highlight().
+				HighlightQuery(es.Match("content", "elasticsearch")),
+		)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"highlight\":{\"highlight_query\":{\"match\":{\"content\":{\"query\":\"elasticsearch\"}}}},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+func Test_Highlight_HighlightQuery_should_handle_bool_query(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(
+			es.Highlight().
+				HighlightQuery(es.Bool().Must(es.Term("status", "active"))),
+		)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"highlight\":{\"highlight_query\":{\"bool\":{\"must\":[{\"term\":{\"status\":{\"value\":\"active\"}}}]}}},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   TagsSchema   ////
+
+func Test_Highlight_should_have_TagsSchema_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	h := es.Highlight()
+
+	// When Then
+	assert.NotNil(t, h.TagsSchema)
+}
+
+func Test_Highlight_TagsSchema_should_create_json_with_tags_schema_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(es.Highlight().TagsSchema("styled"))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"highlight\":{\"tags_schema\":\"styled\"},\"query\":{\"match_all\":{}}}", bodyJSON)
+}
+
+////   HighlightField   ////
+
+func Test_HighlightField_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.HighlightField)
+}
+
+func Test_HighlightField_method_should_create_highlightFieldType(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// Then
+	assert.NotNil(t, hf)
+	assert.IsTypeString(t, "es.highlightFieldType", hf)
+}
+
+func Test_HighlightField_should_create_json_with_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"title\":{}}", bodyJSON)
+}
+
+////   HighlightField FragmentSize   ////
+
+func Test_HighlightField_should_have_FragmentSize_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.FragmentSize)
+}
+
+func Test_HighlightField_FragmentSize_should_create_json_with_fragment_size_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").FragmentSize(150)
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{\"fragment_size\":150}}", bodyJSON)
+}
+
+////   HighlightField NumberOfFragments   ////
+
+func Test_HighlightField_should_have_NumberOfFragments_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.NumberOfFragments)
+}
+
+func Test_HighlightField_NumberOfFragments_should_create_json_with_number_of_fragments_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title").NumberOfFragments(0)
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"title\":{\"number_of_fragments\":0}}", bodyJSON)
+}
+
+////   HighlightField NoMatchSize   ////
+
+func Test_HighlightField_should_have_NoMatchSize_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.NoMatchSize)
+}
+
+func Test_HighlightField_NoMatchSize_should_create_json_with_no_match_size_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").NoMatchSize(150)
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{\"no_match_size\":150}}", bodyJSON)
+}
+
+////   HighlightField PreTags   ////
+
+func Test_HighlightField_should_have_PreTags_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.PreTags)
+}
+
+func Test_HighlightField_PreTags_should_create_json_with_pre_tags_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title").PreTags("<b>")
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"title\":{\"pre_tags\":[\"\\u003cb\\u003e\"]}}", bodyJSON)
+}
+
+////   HighlightField PostTags   ////
+
+func Test_HighlightField_should_have_PostTags_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.PostTags)
+}
+
+func Test_HighlightField_PostTags_should_create_json_with_post_tags_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title").PostTags("</b>")
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"title\":{\"post_tags\":[\"\\u003c/b\\u003e\"]}}", bodyJSON)
+}
+
+////   HighlightField Type   ////
+
+func Test_HighlightField_should_have_Type_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.Type)
+}
+
+func Test_HighlightField_Type_should_create_json_with_type_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title").Type(HighlighterType.Plain)
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"title\":{\"type\":\"plain\"}}", bodyJSON)
+}
+
+////   HighlightField Order   ////
+
+func Test_HighlightField_should_have_Order_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.Order)
+}
+
+func Test_HighlightField_Order_should_create_json_with_order_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").Order("score")
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{\"order\":\"score\"}}", bodyJSON)
+}
+
+////   HighlightField HighlightQuery   ////
+
+func Test_HighlightField_should_have_HighlightQuery_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.HighlightQuery)
+}
+
+func Test_HighlightField_HighlightQuery_should_create_json_with_highlight_query_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").HighlightQuery(es.Match("content", "elasticsearch"))
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{\"highlight_query\":{\"match\":{\"content\":{\"query\":\"elasticsearch\"}}}}}", bodyJSON)
+}
+
+////   HighlightField RequireFieldMatch   ////
+
+func Test_HighlightField_should_have_RequireFieldMatch_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.RequireFieldMatch)
+}
+
+func Test_HighlightField_RequireFieldMatch_should_create_json_with_require_field_match_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").RequireFieldMatch(false)
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{\"require_field_match\":false}}", bodyJSON)
+}
+
+////   HighlightField Fragmenter   ////
+
+func Test_HighlightField_should_have_Fragmenter_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.Fragmenter)
+}
+
+func Test_HighlightField_Fragmenter_should_create_json_with_fragmenter_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").Fragmenter(Fragmenter.Span)
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{\"fragmenter\":\"span\"}}", bodyJSON)
+}
+
+////   HighlightField MatchedFields   ////
+
+func Test_HighlightField_should_have_MatchedFields_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("title")
+
+	// When Then
+	assert.NotNil(t, hf.MatchedFields)
+}
+
+func Test_HighlightField_MatchedFields_should_create_json_with_matched_fields(t *testing.T) {
+	t.Parallel()
+	// Given
+	hf := es.HighlightField("content").MatchedFields("content", "content.plain")
+
+	// When Then
+	assert.NotNil(t, hf)
+	bodyJSON := assert.MarshalWithoutError(t, hf)
+	assert.Equal(t, "{\"content\":{\"matched_fields\":[\"content\",\"content.plain\"]}}", bodyJSON)
+}
+
+////   Complex Highlight Query   ////
+
+func Test_Highlight_should_create_complex_json_with_all_parameters(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(
+		es.Match("content", "elasticsearch"),
+	).
+		Highlight(
+			es.Highlight().
+				PreTags("<em>").
+				PostTags("</em>").
+				Type(HighlighterType.Unified).
+				Order("score").
+				Encoder("html").
+				RequireFieldMatch(true).
+				FragmentSize(150).
+				NumberOfFragments(5).
+				BoundaryScanner(BoundaryScanner.Sentence).
+				BoundaryScannerLocale("en-US").
+				Field(
+					es.HighlightField("title").NumberOfFragments(0),
+					es.HighlightField("content").FragmentSize(200).NumberOfFragments(3),
+				),
+		)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"highlight\":{\"boundary_scanner\":\"sentence\",\"boundary_scanner_locale\":\"en-US\",\"encoder\":\"html\",\"fields\":{\"content\":{\"fragment_size\":200,\"number_of_fragments\":3},\"title\":{\"number_of_fragments\":0}},\"fragment_size\":150,\"number_of_fragments\":5,\"order\":\"score\",\"post_tags\":[\"\\u003c/em\\u003e\"],\"pre_tags\":[\"\\u003cem\\u003e\"],\"require_field_match\":true,\"type\":\"unified\"},\"query\":{\"match\":{\"content\":{\"query\":\"elasticsearch\"}}}}", bodyJSON)
+}
+
+func Test_Highlight_with_field_specific_highlight_query(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(es.MatchAll()).
+		Highlight(
+			es.Highlight().
+				Field(
+					es.HighlightField("content").
+						FragmentSize(150).
+						NumberOfFragments(3).
+						HighlightQuery(es.Match("content", "search")),
+				),
+		)
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"highlight\":{\"fields\":{\"content\":{\"fragment_size\":150,\"highlight_query\":{\"match\":{\"content\":{\"query\":\"search\"}}},\"number_of_fragments\":3}}},\"query\":{\"match_all\":{}}}", bodyJSON)
+}


### PR DESCRIPTION
Implement highlight configuration with full DSL support including:

highlightType (global settings):
- PreTags, PostTags for custom highlight markers
- Field for adding field-specific highlight configurations
- Type (unified, plain, fvh) for highlighter selection
- Order, Encoder, RequireFieldMatch
- FragmentSize, NumberOfFragments, NoMatchSize
- BoundaryScanner, BoundaryChars, BoundaryMaxScan, BoundaryScannerLocale
- Fragmenter, FragmentOffset, MaxFragmentLength, MaxAnalyzedOffset
- HighlightQuery for custom highlight queries
- TagsSchema for built-in tag schemas

highlightFieldType (per-field settings):
- PreTags, PostTags, Type, Order
- FragmentSize, NumberOfFragments, NoMatchSize
- HighlightQuery, RequireFieldMatch, Fragmenter, MatchedFields

Object.Highlight method added to base_query.go for top-level query integration.

New enums:
- highlighter-type: unified, plain, fvh
- boundary-scanner: chars, sentence, word
- fragmenter: simple, span

All implementations follow existing project conventions and patterns.