### PR TITLE
Add missing bucket aggregation types

### DIFF
--- a/es/aggregation_date_histogram.go
+++ b/es/aggregation_date_histogram.go
@@ -1,0 +1,288 @@
+package es
+
+type dateHistogramAggType Object
+
+// DateHistogramAgg creates a date histogram aggregation for a given field.
+//
+// A date histogram aggregation is similar to the normal histogram aggregation, but it can
+// only be applied on date or date range values. The interval is specified using date/time
+// expressions.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month")
+//	// This creates a date histogram aggregation on "timestamp" with monthly intervals.
+//
+// Parameters:
+//   - field: The date field on which the date histogram aggregation is applied.
+//
+// Returns:
+//
+//	An es.dateHistogramAggType object representing the date histogram aggregation.
+func DateHistogramAgg(field string) dateHistogramAggType {
+	return dateHistogramAggType{
+		"date_histogram": Object{
+			"field": field,
+		},
+	}
+}
+
+// CalendarInterval sets the "calendar_interval" parameter in the date histogram aggregation.
+//
+// Calendar-aware intervals understand that daylight savings changes the length of specific
+// days, months have different amounts of days, and leap seconds can be tacked on to a
+// particular year. Supported values: minute, 1m, hour, 1h, day, 1d, week, 1w, month, 1M,
+// quarter, 1q, year, 1y.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month")
+//
+// Parameters:
+//   - calendarInterval: A string representing the calendar interval.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "calendar_interval" parameter set.
+func (d dateHistogramAggType) CalendarInterval(calendarInterval string) dateHistogramAggType {
+	return d.putInTheField("calendar_interval", calendarInterval)
+}
+
+// FixedInterval sets the "fixed_interval" parameter in the date histogram aggregation.
+//
+// Fixed intervals are a fixed number of SI units and never deviate, regardless of where
+// they fall on the calendar. Supported units: ms (milliseconds), s (seconds), m (minutes),
+// h (hours), d (days).
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").FixedInterval("30d")
+//
+// Parameters:
+//   - fixedInterval: A string representing the fixed interval.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "fixed_interval" parameter set.
+func (d dateHistogramAggType) FixedInterval(fixedInterval string) dateHistogramAggType {
+	return d.putInTheField("fixed_interval", fixedInterval)
+}
+
+// Format sets the "format" parameter in the date histogram aggregation.
+//
+// This method specifies the date format used to format the bucket keys in the response.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Format("yyyy-MM-dd")
+//
+// Parameters:
+//   - format: A string representing the date format pattern.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "format" parameter set.
+func (d dateHistogramAggType) Format(format string) dateHistogramAggType {
+	return d.putInTheField("format", format)
+}
+
+// TimeZone sets the "time_zone" parameter in the date histogram aggregation.
+//
+// This method specifies the time zone to use for date calculations. Date-times are stored
+// in UTC in Elasticsearch. By default, all bucketing and rounding is done in UTC. The
+// time_zone parameter can be used to indicate that bucketing should use a different time zone.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("day").TimeZone("-01:00")
+//
+// Parameters:
+//   - timeZone: A string representing the time zone (e.g., "CET", "UTC", "+01:00").
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "time_zone" parameter set.
+func (d dateHistogramAggType) TimeZone(timeZone string) dateHistogramAggType {
+	return d.putInTheField("time_zone", timeZone)
+}
+
+// Offset sets the "offset" parameter in the date histogram aggregation.
+//
+// This method changes the start value of each bucket by the specified positive (+) or
+// negative offset (-) duration, such as 1h for an hour, or 1d for a day.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("day").Offset("+6h")
+//
+// Parameters:
+//   - offset: A string representing the offset duration.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "offset" parameter set.
+func (d dateHistogramAggType) Offset(offset string) dateHistogramAggType {
+	return d.putInTheField("offset", offset)
+}
+
+// MinDocCount sets the minimum document count required for a bucket to be included.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").MinDocCount(1)
+//
+// Parameters:
+//   - minDocCount: The minimum number of documents required for a bucket.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "min_doc_count" parameter set.
+func (d dateHistogramAggType) MinDocCount(minDocCount int) dateHistogramAggType {
+	return d.putInTheField("min_doc_count", minDocCount)
+}
+
+// ExtendedBounds sets the "extended_bounds" parameter in the date histogram aggregation.
+//
+// This method forces the date histogram to start building buckets on a specific min date
+// and keep building buckets up to a max date, even if there are no documents in some buckets.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").
+//		ExtendedBounds("2020-01-01", "2020-12-31")
+//
+// Parameters:
+//   - min: The minimum boundary for the date histogram.
+//   - max: The maximum boundary for the date histogram.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "extended_bounds" parameter set.
+func (d dateHistogramAggType) ExtendedBounds(min, max any) dateHistogramAggType {
+	return d.putInTheField("extended_bounds", Object{
+		"min": min,
+		"max": max,
+	})
+}
+
+// HardBounds sets the "hard_bounds" parameter in the date histogram aggregation.
+//
+// This method limits the range of buckets in the date histogram. Buckets outside the
+// hard bounds will not be generated.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").
+//		HardBounds("2020-01-01", "2020-12-31")
+//
+// Parameters:
+//   - min: The minimum hard boundary.
+//   - max: The maximum hard boundary.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "hard_bounds" parameter set.
+func (d dateHistogramAggType) HardBounds(min, max any) dateHistogramAggType {
+	return d.putInTheField("hard_bounds", Object{
+		"min": min,
+		"max": max,
+	})
+}
+
+// Keyed sets the "keyed" parameter in the date histogram aggregation.
+//
+// This method specifies whether the buckets should be returned as a hash instead of an array.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Keyed(true)
+//
+// Parameters:
+//   - keyed: A boolean indicating whether to return keyed buckets.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "keyed" parameter set.
+func (d dateHistogramAggType) Keyed(keyed bool) dateHistogramAggType {
+	return d.putInTheField("keyed", keyed)
+}
+
+// Missing sets a default value to use for documents that do not contain the field.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Missing("2000-01-01")
+//
+// Parameters:
+//   - missing: The value to use when a document lacks the field.
+//
+// Returns:
+//
+//	An es.dateHistogramAggType object with the "missing" field set.
+func (d dateHistogramAggType) Missing(missing any) dateHistogramAggType {
+	return d.putInTheField("missing", missing)
+}
+
+// Order sets the sorting order of the date histogram buckets.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").
+//		Order(es.AggOrder("_count", Order.Desc))
+//
+// Parameters:
+//   - orders: A variadic list of sorting rules.
+//
+// Returns:
+//
+//	The updated es.dateHistogramAggType object with the "order" parameter set.
+func (d dateHistogramAggType) Order(orders ...aggOrder) dateHistogramAggType {
+	if len(orders) == 1 && orders[0] == nil {
+		return d
+	}
+	return d.putInTheField("order", orders)
+}
+
+// Aggs adds sub-aggregations to the date histogram aggregation.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").
+//		Aggs(es.Agg("avg_price", es.AvgAgg("price")))
+//
+// Parameters:
+//   - aggs: A variadic list of sub-aggregations.
+//
+// Returns:
+//
+//	An es.dateHistogramAggType object with the specified sub-aggregations added.
+func (d dateHistogramAggType) Aggs(aggs ...aggsType) dateHistogramAggType {
+	return genericPutAggsInRoot(d, aggs)
+}
+
+// Meta adds metadata to the date histogram aggregation.
+//
+// Example usage:
+//
+//	agg := es.DateHistogramAgg("timestamp").Meta("description", "Monthly histogram")
+//
+// Parameters:
+//   - key: Metadata key.
+//   - value: Metadata value.
+//
+// Returns:
+//
+//	A modified es.dateHistogramAggType with the meta field set.
+func (d dateHistogramAggType) Meta(key string, value any) dateHistogramAggType {
+	meta, ok := d["meta"].(Object)
+	if !ok {
+		meta = Object{}
+	}
+	meta[key] = value
+	d["meta"] = meta
+	return d
+}
+
+func (d dateHistogramAggType) putInTheField(key string, value any) dateHistogramAggType {
+	return genericPutInTheField(d, "date_histogram", key, value)
+}

--- a/es/aggregation_date_histogram_test.go
+++ b/es/aggregation_date_histogram_test.go
@@ -1,0 +1,366 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   DateHistogramAgg   ////
+
+func Test_DateHistogramAgg_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.DateHistogramAgg)
+}
+
+func Test_DateHistogramAgg_method_should_create_dateHistogramAggType(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// Then
+	assert.NotNil(t, agg)
+	assert.IsTypeString(t, "es.dateHistogramAggType", agg)
+}
+
+func Test_DateHistogramAgg_should_create_json_with_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_histogram\":{\"field\":\"timestamp\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg CalendarInterval   ////
+
+func Test_DateHistogramAgg_should_have_CalendarInterval_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.CalendarInterval)
+}
+
+func Test_DateHistogramAgg_CalendarInterval_should_create_json_with_calendar_interval_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("sales_over_time",
+			es.DateHistogramAgg("date").CalendarInterval("month"),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"sales_over_time\":{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"date\"}}},\"query\":{}}", bodyJSON)
+}
+
+////   DateHistogramAgg FixedInterval   ////
+
+func Test_DateHistogramAgg_should_have_FixedInterval_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.FixedInterval)
+}
+
+func Test_DateHistogramAgg_FixedInterval_should_create_json_with_fixed_interval_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").FixedInterval("30d")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_histogram\":{\"field\":\"timestamp\",\"fixed_interval\":\"30d\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg Format   ////
+
+func Test_DateHistogramAgg_should_have_Format_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.Format)
+}
+
+func Test_DateHistogramAgg_Format_should_create_json_with_format_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Format("yyyy-MM-dd")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\",\"format\":\"yyyy-MM-dd\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg TimeZone   ////
+
+func Test_DateHistogramAgg_should_have_TimeZone_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.TimeZone)
+}
+
+func Test_DateHistogramAgg_TimeZone_should_create_json_with_time_zone_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("day").TimeZone("-01:00")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"day\",\"field\":\"timestamp\",\"time_zone\":\"-01:00\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg Offset   ////
+
+func Test_DateHistogramAgg_should_have_Offset_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.Offset)
+}
+
+func Test_DateHistogramAgg_Offset_should_create_json_with_offset_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("day").Offset("+6h")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"day\",\"field\":\"timestamp\",\"offset\":\"+6h\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg MinDocCount   ////
+
+func Test_DateHistogramAgg_should_have_MinDocCount_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.MinDocCount)
+}
+
+func Test_DateHistogramAgg_MinDocCount_should_create_json_with_min_doc_count_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").MinDocCount(1)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\",\"min_doc_count\":1}}", bodyJSON)
+}
+
+////   DateHistogramAgg ExtendedBounds   ////
+
+func Test_DateHistogramAgg_should_have_ExtendedBounds_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.ExtendedBounds)
+}
+
+func Test_DateHistogramAgg_ExtendedBounds_should_create_json_with_extended_bounds_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").
+		ExtendedBounds("2020-01-01", "2020-12-31")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"extended_bounds\":{\"max\":\"2020-12-31\",\"min\":\"2020-01-01\"},\"field\":\"timestamp\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg HardBounds   ////
+
+func Test_DateHistogramAgg_should_have_HardBounds_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.HardBounds)
+}
+
+func Test_DateHistogramAgg_HardBounds_should_create_json_with_hard_bounds_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").
+		HardBounds("2020-01-01", "2020-12-31")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\",\"hard_bounds\":{\"max\":\"2020-12-31\",\"min\":\"2020-01-01\"}}}", bodyJSON)
+}
+
+////   DateHistogramAgg Keyed   ////
+
+func Test_DateHistogramAgg_should_have_Keyed_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.Keyed)
+}
+
+func Test_DateHistogramAgg_Keyed_should_create_json_with_keyed_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Keyed(true)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\",\"keyed\":true}}", bodyJSON)
+}
+
+////   DateHistogramAgg Missing   ////
+
+func Test_DateHistogramAgg_should_have_Missing_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.Missing)
+}
+
+func Test_DateHistogramAgg_Missing_should_create_json_with_missing_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Missing("2000-01-01")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\",\"missing\":\"2000-01-01\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg Order   ////
+
+func Test_DateHistogramAgg_should_have_Order_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.Order)
+}
+
+func Test_DateHistogramAgg_Order_should_handle_nil_order(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Order(nil)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\"}}", bodyJSON)
+}
+
+////   DateHistogramAgg Aggs   ////
+
+func Test_DateHistogramAgg_should_have_Aggs_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.Aggs)
+}
+
+func Test_DateHistogramAgg_Aggs_should_create_json_with_sub_aggregations(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("sales_over_time",
+			es.DateHistogramAgg("date").CalendarInterval("month").
+				Aggs(es.Agg("total_sales", es.SumAgg("price"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"sales_over_time\":{\"aggs\":{\"total_sales\":{\"sum\":{\"field\":\"price\"}}},\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"date\"}}},\"query\":{}}", bodyJSON)
+}
+
+////   DateHistogramAgg Meta   ////
+
+func Test_DateHistogramAgg_should_have_Meta_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp")
+
+	// When Then
+	assert.NotNil(t, agg.Meta)
+}
+
+func Test_DateHistogramAgg_Meta_should_create_json_with_meta_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").Meta("color", "blue")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_histogram\":{\"field\":\"timestamp\"},\"meta\":{\"color\":\"blue\"}}", bodyJSON)
+}
+
+////   Complex DateHistogramAgg   ////
+
+func Test_DateHistogramAgg_should_create_complex_json_with_all_parameters(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("sales_over_time",
+			es.DateHistogramAgg("date").
+				CalendarInterval("month").
+				Format("yyyy-MM-dd").
+				TimeZone("CET").
+				Offset("+6h").
+				MinDocCount(1).
+				Keyed(true).
+				Aggs(es.Agg("total_sales", es.SumAgg("price"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"sales_over_time\":{\"aggs\":{\"total_sales\":{\"sum\":{\"field\":\"price\"}}},\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"date\",\"format\":\"yyyy-MM-dd\",\"keyed\":true,\"min_doc_count\":1,\"offset\":\"+6h\",\"time_zone\":\"CET\"}}},\"query\":{}}", bodyJSON)
+}

--- a/es/aggregation_date_histogram_test.go
+++ b/es/aggregation_date_histogram_test.go
@@ -3,6 +3,8 @@ package es_test
 import (
 	"testing"
 
+	Order "github.com/Trendyol/es-query-builder/es/enums/sort/order"
+
 	"github.com/Trendyol/es-query-builder/es"
 	"github.com/Trendyol/es-query-builder/test/assert"
 )
@@ -290,6 +292,18 @@ func Test_DateHistogramAgg_Order_should_handle_nil_order(t *testing.T) {
 	bodyJSON := assert.MarshalWithoutError(t, agg)
 	// nolint:golint,lll
 	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\"}}", bodyJSON)
+}
+
+func Test_DateHistogramAgg_Order_should_create_json_with_order_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateHistogramAgg("timestamp").CalendarInterval("month").Order(es.AggOrder("_count", Order.Desc))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_histogram\":{\"calendar_interval\":\"month\",\"field\":\"timestamp\",\"order\":[{\"_count\":\"desc\"}]}}", bodyJSON)
 }
 
 ////   DateHistogramAgg Aggs   ////

--- a/es/aggregation_date_range.go
+++ b/es/aggregation_date_range.go
@@ -1,0 +1,240 @@
+package es
+
+type dateRangeAggType Object
+
+type dateRangeAggEntry Object
+
+// DateRangeAgg creates a date range aggregation for a given field.
+//
+// A date range aggregation is dedicated for date values. The main difference between
+// this aggregation and the normal range aggregation is that the from and to values can
+// be expressed in date math expressions.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").
+//		Format("MM-yyyy").
+//		Range(es.DateRangeEntry().To("now-10M/M")).
+//		Range(es.DateRangeEntry().From("now-10M/M"))
+//
+// Parameters:
+//   - field: The date field on which the date range aggregation is applied.
+//
+// Returns:
+//
+//	An es.dateRangeAggType object representing the date range aggregation.
+func DateRangeAgg(field string) dateRangeAggType {
+	return dateRangeAggType{
+		"date_range": Object{
+			"field": field,
+		},
+	}
+}
+
+// Range adds a date range entry to the date range aggregation.
+//
+// This method appends a date range entry to the "ranges" array of the date range aggregation.
+// Each range entry defines a bucket with optional "from" and "to" date boundaries.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").
+//		Range(es.DateRangeEntry().From("2020-01-01").To("2021-01-01")).
+//		Range(es.DateRangeEntry().From("2021-01-01"))
+//
+// Parameters:
+//   - entry: An es.dateRangeAggEntry object defining the date range boundaries.
+//
+// Returns:
+//
+//	The updated es.dateRangeAggType object with the date range entry added.
+func (d dateRangeAggType) Range(entry dateRangeAggEntry) dateRangeAggType {
+	if dateRangeObj, ok := d["date_range"].(Object); ok {
+		ranges, rOk := dateRangeObj["ranges"].([]dateRangeAggEntry)
+		if !rOk {
+			ranges = make([]dateRangeAggEntry, 0, 1)
+		}
+		dateRangeObj["ranges"] = append(ranges, entry)
+	}
+	return d
+}
+
+// Format sets the "format" parameter in the date range aggregation.
+//
+// This method specifies the date format used to parse the from and to values and
+// to format the bucket keys in the response.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").Format("MM-yyyy")
+//
+// Parameters:
+//   - format: A string representing the date format pattern.
+//
+// Returns:
+//
+//	The updated es.dateRangeAggType object with the "format" parameter set.
+func (d dateRangeAggType) Format(format string) dateRangeAggType {
+	return d.putInTheField("format", format)
+}
+
+// Keyed sets the "keyed" parameter in the date range aggregation.
+//
+// This method specifies whether the buckets should be returned as a hash instead of an array.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").Keyed(true)
+//
+// Parameters:
+//   - keyed: A boolean indicating whether to return keyed buckets.
+//
+// Returns:
+//
+//	The updated es.dateRangeAggType object with the "keyed" parameter set.
+func (d dateRangeAggType) Keyed(keyed bool) dateRangeAggType {
+	return d.putInTheField("keyed", keyed)
+}
+
+// Missing sets a default value to use for documents that do not contain the field.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").Missing("1970-01-01")
+//
+// Parameters:
+//   - missing: The value to use when a document lacks the field.
+//
+// Returns:
+//
+//	An es.dateRangeAggType object with the "missing" field set.
+func (d dateRangeAggType) Missing(missing any) dateRangeAggType {
+	return d.putInTheField("missing", missing)
+}
+
+// TimeZone sets the "time_zone" parameter in the date range aggregation.
+//
+// This method specifies the time zone to use for date calculations.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").TimeZone("CET")
+//
+// Parameters:
+//   - timeZone: A string representing the time zone (e.g., "CET", "UTC", "+01:00").
+//
+// Returns:
+//
+//	The updated es.dateRangeAggType object with the "time_zone" parameter set.
+func (d dateRangeAggType) TimeZone(timeZone string) dateRangeAggType {
+	return d.putInTheField("time_zone", timeZone)
+}
+
+// Aggs adds sub-aggregations to the date range aggregation.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").
+//		Range(es.DateRangeEntry().To("now-10M/M")).
+//		Aggs(es.Agg("avg_price", es.AvgAgg("price")))
+//
+// Parameters:
+//   - aggs: A variadic list of sub-aggregations.
+//
+// Returns:
+//
+//	An es.dateRangeAggType object with the specified sub-aggregations added.
+func (d dateRangeAggType) Aggs(aggs ...aggsType) dateRangeAggType {
+	return genericPutAggsInRoot(d, aggs)
+}
+
+// Meta adds metadata to the date range aggregation.
+//
+// Example usage:
+//
+//	agg := es.DateRangeAgg("date").Meta("description", "Date ranges")
+//
+// Parameters:
+//   - key: Metadata key.
+//   - value: Metadata value.
+//
+// Returns:
+//
+//	A modified es.dateRangeAggType with the meta field set.
+func (d dateRangeAggType) Meta(key string, value any) dateRangeAggType {
+	meta, ok := d["meta"].(Object)
+	if !ok {
+		meta = Object{}
+	}
+	meta[key] = value
+	d["meta"] = meta
+	return d
+}
+
+func (d dateRangeAggType) putInTheField(key string, value any) dateRangeAggType {
+	return genericPutInTheField(d, "date_range", key, value)
+}
+
+// DateRangeEntry creates a new date range entry for use in a date range aggregation.
+//
+// Example usage:
+//
+//	entry := es.DateRangeEntry().From("2020-01-01").To("2021-01-01")
+//
+// Returns:
+//
+//	An es.dateRangeAggEntry object ready for configuration.
+func DateRangeEntry() dateRangeAggEntry {
+	return dateRangeAggEntry{}
+}
+
+// From sets the "from" boundary of the date range entry (inclusive).
+//
+// Example usage:
+//
+//	entry := es.DateRangeEntry().From("now-10M/M")
+//
+// Parameters:
+//   - from: The lower date boundary of the range.
+//
+// Returns:
+//
+//	The updated es.dateRangeAggEntry object with the "from" boundary set.
+func (e dateRangeAggEntry) From(from any) dateRangeAggEntry {
+	e["from"] = from
+	return e
+}
+
+// To sets the "to" boundary of the date range entry (exclusive).
+//
+// Example usage:
+//
+//	entry := es.DateRangeEntry().To("now-10M/M")
+//
+// Parameters:
+//   - to: The upper date boundary of the range.
+//
+// Returns:
+//
+//	The updated es.dateRangeAggEntry object with the "to" boundary set.
+func (e dateRangeAggEntry) To(to any) dateRangeAggEntry {
+	e["to"] = to
+	return e
+}
+
+// Key sets a custom key for the date range entry bucket.
+//
+// Example usage:
+//
+//	entry := es.DateRangeEntry().Key("last_year").From("now-1y/y").To("now/y")
+//
+// Parameters:
+//   - key: A string representing the custom bucket key.
+//
+// Returns:
+//
+//	The updated es.dateRangeAggEntry object with the "key" set.
+func (e dateRangeAggEntry) Key(key string) dateRangeAggEntry {
+	e["key"] = key
+	return e
+}

--- a/es/aggregation_date_range_test.go
+++ b/es/aggregation_date_range_test.go
@@ -1,0 +1,287 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   DateRangeAgg   ////
+
+func Test_DateRangeAgg_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.DateRangeAgg)
+}
+
+func Test_DateRangeAgg_method_should_create_dateRangeAggType(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// Then
+	assert.NotNil(t, agg)
+	assert.IsTypeString(t, "es.dateRangeAggType", agg)
+}
+
+func Test_DateRangeAgg_should_create_json_with_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\"}}", bodyJSON)
+}
+
+////   DateRangeAgg Range   ////
+
+func Test_DateRangeAgg_should_have_Range_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg.Range)
+}
+
+func Test_DateRangeAgg_Range_should_create_json_with_ranges(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("date_ranges",
+			es.DateRangeAgg("date").
+				Range(es.DateRangeEntry().To("now-10M/M")).
+				Range(es.DateRangeEntry().From("now-10M/M")),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"date_ranges\":{\"date_range\":{\"field\":\"date\",\"ranges\":[{\"to\":\"now-10M/M\"},{\"from\":\"now-10M/M\"}]}}},\"query\":{}}", bodyJSON)
+}
+
+func Test_DateRangeAgg_Range_should_create_json_with_keyed_ranges(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date").
+		Range(es.DateRangeEntry().Key("last_year").From("now-1y/y").To("now/y")).
+		Range(es.DateRangeEntry().Key("this_year").From("now/y"))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\",\"ranges\":[{\"from\":\"now-1y/y\",\"key\":\"last_year\",\"to\":\"now/y\"},{\"from\":\"now/y\",\"key\":\"this_year\"}]}}", bodyJSON)
+}
+
+////   DateRangeAgg Format   ////
+
+func Test_DateRangeAgg_should_have_Format_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg.Format)
+}
+
+func Test_DateRangeAgg_Format_should_create_json_with_format_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date").Format("MM-yyyy")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\",\"format\":\"MM-yyyy\"}}", bodyJSON)
+}
+
+////   DateRangeAgg Keyed   ////
+
+func Test_DateRangeAgg_should_have_Keyed_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg.Keyed)
+}
+
+func Test_DateRangeAgg_Keyed_should_create_json_with_keyed_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date").Keyed(true)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\",\"keyed\":true}}", bodyJSON)
+}
+
+////   DateRangeAgg Missing   ////
+
+func Test_DateRangeAgg_should_have_Missing_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg.Missing)
+}
+
+func Test_DateRangeAgg_Missing_should_create_json_with_missing_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date").Missing("1970-01-01")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\",\"missing\":\"1970-01-01\"}}", bodyJSON)
+}
+
+////   DateRangeAgg TimeZone   ////
+
+func Test_DateRangeAgg_should_have_TimeZone_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg.TimeZone)
+}
+
+func Test_DateRangeAgg_TimeZone_should_create_json_with_time_zone_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date").TimeZone("CET")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\",\"time_zone\":\"CET\"}}", bodyJSON)
+}
+
+////   DateRangeAgg Aggs   ////
+
+func Test_DateRangeAgg_should_have_Aggs_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg.Aggs)
+}
+
+func Test_DateRangeAgg_Aggs_should_create_json_with_sub_aggregations(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("date_ranges",
+			es.DateRangeAgg("date").
+				Range(es.DateRangeEntry().To("now-10M/M")).
+				Aggs(es.Agg("avg_price", es.AvgAgg("price"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"date_ranges\":{\"aggs\":{\"avg_price\":{\"avg\":{\"field\":\"price\"}}},\"date_range\":{\"field\":\"date\",\"ranges\":[{\"to\":\"now-10M/M\"}]}}},\"query\":{}}", bodyJSON)
+}
+
+////   DateRangeAgg Meta   ////
+
+func Test_DateRangeAgg_should_have_Meta_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date")
+
+	// When Then
+	assert.NotNil(t, agg.Meta)
+}
+
+func Test_DateRangeAgg_Meta_should_create_json_with_meta_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date").Meta("color", "blue")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\"},\"meta\":{\"color\":\"blue\"}}", bodyJSON)
+}
+
+////   DateRangeEntry   ////
+
+func Test_DateRangeEntry_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.DateRangeEntry)
+}
+
+func Test_DateRangeEntry_method_should_create_dateRangeAggEntry(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.DateRangeEntry()
+
+	// Then
+	assert.NotNil(t, entry)
+	assert.IsTypeString(t, "es.dateRangeAggEntry", entry)
+}
+
+func Test_DateRangeEntry_From_should_create_json_with_from_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.DateRangeEntry().From("now-10M/M")
+
+	// When Then
+	assert.NotNil(t, entry)
+	bodyJSON := assert.MarshalWithoutError(t, entry)
+	assert.Equal(t, "{\"from\":\"now-10M/M\"}", bodyJSON)
+}
+
+func Test_DateRangeEntry_To_should_create_json_with_to_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.DateRangeEntry().To("now-10M/M")
+
+	// When Then
+	assert.NotNil(t, entry)
+	bodyJSON := assert.MarshalWithoutError(t, entry)
+	assert.Equal(t, "{\"to\":\"now-10M/M\"}", bodyJSON)
+}
+
+func Test_DateRangeEntry_Key_should_create_json_with_key_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.DateRangeEntry().Key("last_year").From("now-1y/y").To("now/y")
+
+	// When Then
+	assert.NotNil(t, entry)
+	bodyJSON := assert.MarshalWithoutError(t, entry)
+	assert.Equal(t, "{\"from\":\"now-1y/y\",\"key\":\"last_year\",\"to\":\"now/y\"}", bodyJSON)
+}
+
+////   Complex DateRangeAgg   ////
+
+func Test_DateRangeAgg_should_create_complex_json_with_all_parameters(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.DateRangeAgg("date").
+		Format("MM-yyyy").
+		TimeZone("CET").
+		Keyed(true).
+		Range(es.DateRangeEntry().To("now-10M/M")).
+		Range(es.DateRangeEntry().From("now-10M/M"))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"date_range\":{\"field\":\"date\",\"format\":\"MM-yyyy\",\"keyed\":true,\"ranges\":[{\"to\":\"now-10M/M\"},{\"from\":\"now-10M/M\"}],\"time_zone\":\"CET\"}}", bodyJSON)
+}

--- a/es/aggregation_filter.go
+++ b/es/aggregation_filter.go
@@ -1,0 +1,75 @@
+package es
+
+type filterAggType Object
+
+// FilterAgg creates a filter aggregation that narrows the set of documents to those matching a query.
+//
+// A filter aggregation defines a single bucket of all the documents in the current document set
+// context that match a specified filter. Often this will be used to narrow down the current
+// aggregation context to a specific set of documents.
+//
+// Example usage:
+//
+//	agg := es.FilterAgg(es.Term("status", "active"))
+//	// This creates a filter aggregation that only includes documents where status is "active".
+//
+// Parameters:
+//   - filter: The query clause to filter documents. It can be of any type.
+//
+// Returns:
+//
+//	An es.filterAggType object representing the filter aggregation.
+func FilterAgg(filter any) filterAggType {
+	if field, ok := correctType(filter); ok {
+		return filterAggType{
+			"filter": field,
+		}
+	}
+	return filterAggType{
+		"filter": Object{},
+	}
+}
+
+// Aggs adds sub-aggregations to the filter aggregation.
+//
+// This method allows performing additional aggregations on the filtered set of documents.
+//
+// Example usage:
+//
+//	agg := es.FilterAgg(es.Term("status", "active")).
+//		Aggs(es.Agg("avg_price", es.AvgAgg("price")))
+//
+// Parameters:
+//   - aggs: A variadic list of sub-aggregations.
+//
+// Returns:
+//
+//	An es.filterAggType object with the specified sub-aggregations added.
+func (f filterAggType) Aggs(aggs ...aggsType) filterAggType {
+	return genericPutAggsInRoot(f, aggs)
+}
+
+// Meta adds metadata to the filter aggregation.
+//
+// This can store additional information that does not affect the aggregation execution.
+//
+// Example usage:
+//
+//	agg := es.FilterAgg(es.Term("status", "active")).Meta("description", "Active items")
+//
+// Parameters:
+//   - key: Metadata key.
+//   - value: Metadata value.
+//
+// Returns:
+//
+//	A modified es.filterAggType with the meta field set.
+func (f filterAggType) Meta(key string, value any) filterAggType {
+	meta, ok := f["meta"].(Object)
+	if !ok {
+		meta = Object{}
+	}
+	meta[key] = value
+	f["meta"] = meta
+	return f
+}

--- a/es/aggregation_filter_test.go
+++ b/es/aggregation_filter_test.go
@@ -1,0 +1,115 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   FilterAgg   ////
+
+func Test_FilterAgg_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.FilterAgg)
+}
+
+func Test_FilterAgg_method_should_create_filterAggType(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FilterAgg(es.Term("status", "active"))
+
+	// Then
+	assert.NotNil(t, agg)
+	assert.IsTypeString(t, "es.filterAggType", agg)
+}
+
+func Test_FilterAgg_should_create_json_with_filter(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("active_products", es.FilterAgg(es.Term("status", "active"))))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"active_products\":{\"filter\":{\"term\":{\"status\":{\"value\":\"active\"}}}}},\"query\":{}}", bodyJSON)
+}
+
+func Test_FilterAgg_should_handle_nil_filter(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FilterAgg(nil)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"filter\":{}}", bodyJSON)
+}
+
+func Test_FilterAgg_should_handle_bool_filter(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("filtered",
+			es.FilterAgg(es.Bool().Must(es.Term("status", "active"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"filtered\":{\"filter\":{\"bool\":{\"must\":[{\"term\":{\"status\":{\"value\":\"active\"}}}]}}}},\"query\":{}}", bodyJSON)
+}
+
+////   FilterAgg Aggs   ////
+
+func Test_FilterAgg_should_have_Aggs_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FilterAgg(es.Term("status", "active"))
+
+	// When Then
+	assert.NotNil(t, agg.Aggs)
+}
+
+func Test_FilterAgg_Aggs_should_create_json_with_sub_aggregations(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("active_products",
+			es.FilterAgg(es.Term("status", "active")).
+				Aggs(es.Agg("avg_price", es.AvgAgg("price"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"active_products\":{\"aggs\":{\"avg_price\":{\"avg\":{\"field\":\"price\"}}},\"filter\":{\"term\":{\"status\":{\"value\":\"active\"}}}}},\"query\":{}}", bodyJSON)
+}
+
+////   FilterAgg Meta   ////
+
+func Test_FilterAgg_should_have_Meta_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FilterAgg(es.Term("status", "active"))
+
+	// When Then
+	assert.NotNil(t, agg.Meta)
+}
+
+func Test_FilterAgg_Meta_should_create_json_with_meta_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FilterAgg(es.Term("status", "active")).Meta("color", "blue")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"filter\":{\"term\":{\"status\":{\"value\":\"active\"}}},\"meta\":{\"color\":\"blue\"}}", bodyJSON)
+}

--- a/es/aggregation_filters.go
+++ b/es/aggregation_filters.go
@@ -1,0 +1,143 @@
+package es
+
+type filtersAggType Object
+
+// FiltersAgg creates a filters aggregation that defines a multi-bucket aggregation where each
+// bucket is associated with a named filter. Each bucket will collect all documents that match
+// its associated filter.
+//
+// Example usage:
+//
+//	agg := es.FiltersAgg().
+//		Filter("errors", es.Term("status", "error")).
+//		Filter("warnings", es.Term("status", "warning"))
+//	// This creates a filters aggregation with two named buckets.
+//
+// Returns:
+//
+//	An es.filtersAggType object representing the filters aggregation.
+func FiltersAgg() filtersAggType {
+	return filtersAggType{
+		"filters": Object{
+			"filters": Object{},
+		},
+	}
+}
+
+// Filter adds a named filter to the filters aggregation.
+//
+// This method adds a named filter bucket to the filters aggregation. Each named filter
+// defines a bucket that will collect all documents matching the filter query.
+//
+// Example usage:
+//
+//	agg := es.FiltersAgg().
+//		Filter("active", es.Term("status", "active")).
+//		Filter("inactive", es.Term("status", "inactive"))
+//
+// Parameters:
+//   - name: The name of the filter bucket.
+//   - filter: The query clause for this filter bucket.
+//
+// Returns:
+//
+//	The updated es.filtersAggType object with the named filter added.
+func (f filtersAggType) Filter(name string, filter any) filtersAggType {
+	if filtersObj, ok := f["filters"].(Object); ok {
+		if filters, fOk := filtersObj["filters"].(Object); fOk {
+			if field, cOk := correctType(filter); cOk {
+				filters[name] = field
+			}
+		}
+	}
+	return f
+}
+
+// OtherBucket sets the "other_bucket" parameter in the filters aggregation.
+//
+// This method adds a bucket to the response which will contain all documents that do
+// not match any of the given filters. When set to true, an additional bucket is created
+// for documents not matching any filter.
+//
+// Example usage:
+//
+//	agg := es.FiltersAgg().
+//		Filter("errors", es.Term("status", "error")).
+//		OtherBucket(true)
+//
+// Parameters:
+//   - otherBucket: A boolean indicating whether to include an "other" bucket.
+//
+// Returns:
+//
+//	The updated es.filtersAggType object with the "other_bucket" parameter set.
+func (f filtersAggType) OtherBucket(otherBucket bool) filtersAggType {
+	return f.putInTheField("other_bucket", otherBucket)
+}
+
+// OtherBucketKey sets the "other_bucket_key" parameter in the filters aggregation.
+//
+// This method sets the key for the "other" bucket. By default, the other bucket is
+// named "_other_". This parameter allows customizing that name.
+//
+// Example usage:
+//
+//	agg := es.FiltersAgg().
+//		Filter("errors", es.Term("status", "error")).
+//		OtherBucket(true).
+//		OtherBucketKey("remaining")
+//
+// Parameters:
+//   - otherBucketKey: A string representing the key for the other bucket.
+//
+// Returns:
+//
+//	The updated es.filtersAggType object with the "other_bucket_key" parameter set.
+func (f filtersAggType) OtherBucketKey(otherBucketKey string) filtersAggType {
+	return f.putInTheField("other_bucket_key", otherBucketKey)
+}
+
+// Aggs adds sub-aggregations to the filters aggregation.
+//
+// Example usage:
+//
+//	agg := es.FiltersAgg().
+//		Filter("errors", es.Term("status", "error")).
+//		Aggs(es.Agg("avg_price", es.AvgAgg("price")))
+//
+// Parameters:
+//   - aggs: A variadic list of sub-aggregations.
+//
+// Returns:
+//
+//	An es.filtersAggType object with the specified sub-aggregations added.
+func (f filtersAggType) Aggs(aggs ...aggsType) filtersAggType {
+	return genericPutAggsInRoot(f, aggs)
+}
+
+// Meta adds metadata to the filters aggregation.
+//
+// Example usage:
+//
+//	agg := es.FiltersAgg().Meta("description", "Status filters")
+//
+// Parameters:
+//   - key: Metadata key.
+//   - value: Metadata value.
+//
+// Returns:
+//
+//	A modified es.filtersAggType with the meta field set.
+func (f filtersAggType) Meta(key string, value any) filtersAggType {
+	meta, ok := f["meta"].(Object)
+	if !ok {
+		meta = Object{}
+	}
+	meta[key] = value
+	f["meta"] = meta
+	return f
+}
+
+func (f filtersAggType) putInTheField(key string, value any) filtersAggType {
+	return genericPutInTheField(f, "filters", key, value)
+}

--- a/es/aggregation_filters_test.go
+++ b/es/aggregation_filters_test.go
@@ -1,0 +1,191 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   FiltersAgg   ////
+
+func Test_FiltersAgg_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.FiltersAgg)
+}
+
+func Test_FiltersAgg_method_should_create_filtersAggType(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg()
+
+	// Then
+	assert.NotNil(t, agg)
+	assert.IsTypeString(t, "es.filtersAggType", agg)
+}
+
+func Test_FiltersAgg_should_create_json_with_empty_filters(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg()
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"filters\":{\"filters\":{}}}", bodyJSON)
+}
+
+////   FiltersAgg Filter   ////
+
+func Test_FiltersAgg_should_have_Filter_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg()
+
+	// When Then
+	assert.NotNil(t, agg.Filter)
+}
+
+func Test_FiltersAgg_Filter_should_create_json_with_named_filter(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg().
+		Filter("errors", es.Term("status", "error"))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"filters\":{\"filters\":{\"errors\":{\"term\":{\"status\":{\"value\":\"error\"}}}}}}", bodyJSON)
+}
+
+func Test_FiltersAgg_Filter_should_create_json_with_multiple_named_filters(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("messages",
+			es.FiltersAgg().
+				Filter("errors", es.Match("body", "error")).
+				Filter("warnings", es.Match("body", "warning")),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"messages\":{\"filters\":{\"filters\":{\"errors\":{\"match\":{\"body\":{\"query\":\"error\"}}},\"warnings\":{\"match\":{\"body\":{\"query\":\"warning\"}}}}}}},\"query\":{}}", bodyJSON)
+}
+
+func Test_FiltersAgg_Filter_should_handle_bool_filter(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg().
+		Filter("active", es.Bool().Must(es.Term("status", "active")))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"filters\":{\"filters\":{\"active\":{\"bool\":{\"must\":[{\"term\":{\"status\":{\"value\":\"active\"}}}]}}}}}", bodyJSON)
+}
+
+////   FiltersAgg OtherBucket   ////
+
+func Test_FiltersAgg_should_have_OtherBucket_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg()
+
+	// When Then
+	assert.NotNil(t, agg.OtherBucket)
+}
+
+func Test_FiltersAgg_OtherBucket_should_create_json_with_other_bucket_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg().
+		Filter("errors", es.Term("status", "error")).
+		OtherBucket(true)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"filters\":{\"filters\":{\"errors\":{\"term\":{\"status\":{\"value\":\"error\"}}}},\"other_bucket\":true}}", bodyJSON)
+}
+
+////   FiltersAgg OtherBucketKey   ////
+
+func Test_FiltersAgg_should_have_OtherBucketKey_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg()
+
+	// When Then
+	assert.NotNil(t, agg.OtherBucketKey)
+}
+
+func Test_FiltersAgg_OtherBucketKey_should_create_json_with_other_bucket_key_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg().
+		Filter("errors", es.Term("status", "error")).
+		OtherBucket(true).
+		OtherBucketKey("remaining")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"filters\":{\"filters\":{\"errors\":{\"term\":{\"status\":{\"value\":\"error\"}}}},\"other_bucket\":true,\"other_bucket_key\":\"remaining\"}}", bodyJSON)
+}
+
+////   FiltersAgg Aggs   ////
+
+func Test_FiltersAgg_should_have_Aggs_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg()
+
+	// When Then
+	assert.NotNil(t, agg.Aggs)
+}
+
+func Test_FiltersAgg_Aggs_should_create_json_with_sub_aggregations(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("messages",
+			es.FiltersAgg().
+				Filter("errors", es.Match("body", "error")).
+				Aggs(es.Agg("avg_price", es.AvgAgg("price"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"messages\":{\"aggs\":{\"avg_price\":{\"avg\":{\"field\":\"price\"}}},\"filters\":{\"filters\":{\"errors\":{\"match\":{\"body\":{\"query\":\"error\"}}}}}}},\"query\":{}}", bodyJSON)
+}
+
+////   FiltersAgg Meta   ////
+
+func Test_FiltersAgg_should_have_Meta_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg()
+
+	// When Then
+	assert.NotNil(t, agg.Meta)
+}
+
+func Test_FiltersAgg_Meta_should_create_json_with_meta_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.FiltersAgg().Meta("color", "blue")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"filters\":{\"filters\":{}},\"meta\":{\"color\":\"blue\"}}", bodyJSON)
+}

--- a/es/aggregation_histogram.go
+++ b/es/aggregation_histogram.go
@@ -1,0 +1,210 @@
+package es
+
+type histogramAggType Object
+
+// HistogramAgg creates a histogram aggregation for a given field.
+//
+// A histogram aggregation groups documents into fixed-size intervals (buckets) based on
+// the values of a numeric field. Each bucket covers an interval of the specified size.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50)
+//	// This creates a histogram aggregation on "price" with an interval of 50.
+//
+// Parameters:
+//   - field: The numeric field on which the histogram aggregation is applied.
+//   - interval: The interval size for each bucket.
+//
+// Returns:
+//
+//	An es.histogramAggType object representing the histogram aggregation.
+func HistogramAgg(field string, interval float64) histogramAggType {
+	return histogramAggType{
+		"histogram": Object{
+			"field":    field,
+			"interval": interval,
+		},
+	}
+}
+
+// MinDocCount sets the minimum document count required for a bucket to be included.
+//
+// By default, the response will fill gaps in the histogram with empty buckets. Setting
+// min_doc_count to a value greater than 0 will only return buckets that meet the threshold.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).MinDocCount(1)
+//
+// Parameters:
+//   - minDocCount: The minimum number of documents required for a bucket.
+//
+// Returns:
+//
+//	The updated es.histogramAggType object with the "min_doc_count" parameter set.
+func (h histogramAggType) MinDocCount(minDocCount int) histogramAggType {
+	return h.putInTheField("min_doc_count", minDocCount)
+}
+
+// ExtendedBounds sets the "extended_bounds" parameter in the histogram aggregation.
+//
+// This method forces the histogram to start building buckets on a specific min value and
+// keep building buckets up to a max value, even if there are no documents in some buckets.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).ExtendedBounds(0, 500)
+//
+// Parameters:
+//   - min: The minimum boundary for the histogram.
+//   - max: The maximum boundary for the histogram.
+//
+// Returns:
+//
+//	The updated es.histogramAggType object with the "extended_bounds" parameter set.
+func (h histogramAggType) ExtendedBounds(min, max float64) histogramAggType {
+	return h.putInTheField("extended_bounds", Object{
+		"min": min,
+		"max": max,
+	})
+}
+
+// HardBounds sets the "hard_bounds" parameter in the histogram aggregation.
+//
+// This method limits the range of buckets in the histogram. Buckets outside the hard
+// bounds will not be generated.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).HardBounds(0, 1000)
+//
+// Parameters:
+//   - min: The minimum hard boundary.
+//   - max: The maximum hard boundary.
+//
+// Returns:
+//
+//	The updated es.histogramAggType object with the "hard_bounds" parameter set.
+func (h histogramAggType) HardBounds(min, max float64) histogramAggType {
+	return h.putInTheField("hard_bounds", Object{
+		"min": min,
+		"max": max,
+	})
+}
+
+// Offset sets the "offset" parameter in the histogram aggregation.
+//
+// This method shifts the bucket boundaries by the specified offset. For example, with
+// an interval of 10 and an offset of 5, the buckets would be [5, 15), [15, 25), etc.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 10).Offset(5)
+//
+// Parameters:
+//   - offset: The offset value to shift bucket boundaries.
+//
+// Returns:
+//
+//	The updated es.histogramAggType object with the "offset" parameter set.
+func (h histogramAggType) Offset(offset float64) histogramAggType {
+	return h.putInTheField("offset", offset)
+}
+
+// Keyed sets the "keyed" parameter in the histogram aggregation.
+//
+// This method specifies whether the buckets should be returned as a hash instead of an array.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).Keyed(true)
+//
+// Parameters:
+//   - keyed: A boolean indicating whether to return keyed buckets.
+//
+// Returns:
+//
+//	The updated es.histogramAggType object with the "keyed" parameter set.
+func (h histogramAggType) Keyed(keyed bool) histogramAggType {
+	return h.putInTheField("keyed", keyed)
+}
+
+// Missing sets a default value to use for documents that do not contain the field.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).Missing(0)
+//
+// Parameters:
+//   - missing: The value to use when a document lacks the field.
+//
+// Returns:
+//
+//	An es.histogramAggType object with the "missing" field set.
+func (h histogramAggType) Missing(missing any) histogramAggType {
+	return h.putInTheField("missing", missing)
+}
+
+// Order sets the sorting order of the histogram buckets.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).Order(es.AggOrder("_count", Order.Desc))
+//
+// Parameters:
+//   - orders: A variadic list of sorting rules.
+//
+// Returns:
+//
+//	The updated es.histogramAggType object with the "order" parameter set.
+func (h histogramAggType) Order(orders ...aggOrder) histogramAggType {
+	if len(orders) == 1 && orders[0] == nil {
+		return h
+	}
+	return h.putInTheField("order", orders)
+}
+
+// Aggs adds sub-aggregations to the histogram aggregation.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).
+//		Aggs(es.Agg("avg_score", es.AvgAgg("score")))
+//
+// Parameters:
+//   - aggs: A variadic list of sub-aggregations.
+//
+// Returns:
+//
+//	An es.histogramAggType object with the specified sub-aggregations added.
+func (h histogramAggType) Aggs(aggs ...aggsType) histogramAggType {
+	return genericPutAggsInRoot(h, aggs)
+}
+
+// Meta adds metadata to the histogram aggregation.
+//
+// Example usage:
+//
+//	agg := es.HistogramAgg("price", 50).Meta("description", "Price histogram")
+//
+// Parameters:
+//   - key: Metadata key.
+//   - value: Metadata value.
+//
+// Returns:
+//
+//	A modified es.histogramAggType with the meta field set.
+func (h histogramAggType) Meta(key string, value any) histogramAggType {
+	meta, ok := h["meta"].(Object)
+	if !ok {
+		meta = Object{}
+	}
+	meta[key] = value
+	h["meta"] = meta
+	return h
+}
+
+func (h histogramAggType) putInTheField(key string, value any) histogramAggType {
+	return genericPutInTheField(h, "histogram", key, value)
+}

--- a/es/aggregation_histogram_test.go
+++ b/es/aggregation_histogram_test.go
@@ -1,0 +1,241 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   HistogramAgg   ////
+
+func Test_HistogramAgg_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.HistogramAgg)
+}
+
+func Test_HistogramAgg_method_should_create_histogramAggType(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// Then
+	assert.NotNil(t, agg)
+	assert.IsTypeString(t, "es.histogramAggType", agg)
+}
+
+func Test_HistogramAgg_should_create_json_with_field_and_interval(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("prices", es.HistogramAgg("price", 50)))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	assert.Equal(t, "{\"aggs\":{\"prices\":{\"histogram\":{\"field\":\"price\",\"interval\":50}}},\"query\":{}}", bodyJSON)
+}
+
+////   HistogramAgg MinDocCount   ////
+
+func Test_HistogramAgg_should_have_MinDocCount_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.MinDocCount)
+}
+
+func Test_HistogramAgg_MinDocCount_should_create_json_with_min_doc_count_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).MinDocCount(1)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":50,\"min_doc_count\":1}}", bodyJSON)
+}
+
+////   HistogramAgg ExtendedBounds   ////
+
+func Test_HistogramAgg_should_have_ExtendedBounds_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.ExtendedBounds)
+}
+
+func Test_HistogramAgg_ExtendedBounds_should_create_json_with_extended_bounds_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).ExtendedBounds(0, 500)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"extended_bounds\":{\"max\":500,\"min\":0},\"field\":\"price\",\"interval\":50}}", bodyJSON)
+}
+
+////   HistogramAgg HardBounds   ////
+
+func Test_HistogramAgg_should_have_HardBounds_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.HardBounds)
+}
+
+func Test_HistogramAgg_HardBounds_should_create_json_with_hard_bounds_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).HardBounds(0, 1000)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"hard_bounds\":{\"max\":1000,\"min\":0},\"interval\":50}}", bodyJSON)
+}
+
+////   HistogramAgg Offset   ////
+
+func Test_HistogramAgg_should_have_Offset_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 10)
+
+	// When Then
+	assert.NotNil(t, agg.Offset)
+}
+
+func Test_HistogramAgg_Offset_should_create_json_with_offset_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 10).Offset(5)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":10,\"offset\":5}}", bodyJSON)
+}
+
+////   HistogramAgg Keyed   ////
+
+func Test_HistogramAgg_should_have_Keyed_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.Keyed)
+}
+
+func Test_HistogramAgg_Keyed_should_create_json_with_keyed_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).Keyed(true)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":50,\"keyed\":true}}", bodyJSON)
+}
+
+////   HistogramAgg Missing   ////
+
+func Test_HistogramAgg_should_have_Missing_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.Missing)
+}
+
+func Test_HistogramAgg_Missing_should_create_json_with_missing_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).Missing(0)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":50,\"missing\":0}}", bodyJSON)
+}
+
+////   HistogramAgg Order   ////
+
+func Test_HistogramAgg_should_have_Order_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.Order)
+}
+
+func Test_HistogramAgg_Order_should_handle_nil_order(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).Order(nil)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":50}}", bodyJSON)
+}
+
+////   HistogramAgg Aggs   ////
+
+func Test_HistogramAgg_should_have_Aggs_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.Aggs)
+}
+
+func Test_HistogramAgg_Aggs_should_create_json_with_sub_aggregations(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("prices",
+			es.HistogramAgg("price", 50).
+				Aggs(es.Agg("avg_score", es.AvgAgg("score"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"prices\":{\"aggs\":{\"avg_score\":{\"avg\":{\"field\":\"score\"}}},\"histogram\":{\"field\":\"price\",\"interval\":50}}},\"query\":{}}", bodyJSON)
+}
+
+////   HistogramAgg Meta   ////
+
+func Test_HistogramAgg_should_have_Meta_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50)
+
+	// When Then
+	assert.NotNil(t, agg.Meta)
+}
+
+func Test_HistogramAgg_Meta_should_create_json_with_meta_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).Meta("color", "blue")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":50},\"meta\":{\"color\":\"blue\"}}", bodyJSON)
+}

--- a/es/aggregation_histogram_test.go
+++ b/es/aggregation_histogram_test.go
@@ -3,6 +3,8 @@ package es_test
 import (
 	"testing"
 
+	Order "github.com/Trendyol/es-query-builder/es/enums/sort/order"
+
 	"github.com/Trendyol/es-query-builder/es"
 	"github.com/Trendyol/es-query-builder/test/assert"
 )
@@ -189,6 +191,17 @@ func Test_HistogramAgg_Order_should_handle_nil_order(t *testing.T) {
 	assert.NotNil(t, agg)
 	bodyJSON := assert.MarshalWithoutError(t, agg)
 	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":50}}", bodyJSON)
+}
+
+func Test_HistogramAgg_Order_should_create_json_with_order_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.HistogramAgg("price", 50).Order(es.AggOrder("_count", Order.Desc))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"histogram\":{\"field\":\"price\",\"interval\":50,\"order\":[{\"_count\":\"desc\"}]}}", bodyJSON)
 }
 
 ////   HistogramAgg Aggs   ////

--- a/es/aggregation_range.go
+++ b/es/aggregation_range.go
@@ -1,0 +1,204 @@
+package es
+
+type rangeAggType Object
+
+type rangeAggEntry Object
+
+// RangeAgg creates a range aggregation for a given field.
+//
+// A range aggregation allows you to define a set of ranges, each representing a bucket.
+// During the aggregation process, the values extracted from each document will be checked
+// against each bucket range and the relevant document will be "bucketed".
+//
+// Example usage:
+//
+//	agg := es.RangeAgg("price").
+//		Range(es.RangeEntry().To(50)).
+//		Range(es.RangeEntry().From(50).To(100)).
+//		Range(es.RangeEntry().From(100))
+//
+// Parameters:
+//   - field: The field on which the range aggregation is applied.
+//
+// Returns:
+//
+//	An es.rangeAggType object representing the range aggregation.
+func RangeAgg(field string) rangeAggType {
+	return rangeAggType{
+		"range": Object{
+			"field": field,
+		},
+	}
+}
+
+// Range adds a range entry to the range aggregation.
+//
+// This method appends a range entry to the "ranges" array of the range aggregation.
+// Each range entry defines a bucket with optional "from" and "to" boundaries.
+//
+// Example usage:
+//
+//	agg := es.RangeAgg("price").
+//		Range(es.RangeEntry().From(10).To(50)).
+//		Range(es.RangeEntry().From(50).To(100))
+//
+// Parameters:
+//   - entry: An es.rangeAggEntry object defining the range boundaries.
+//
+// Returns:
+//
+//	The updated es.rangeAggType object with the range entry added.
+func (r rangeAggType) Range(entry rangeAggEntry) rangeAggType {
+	if rangeObj, ok := r["range"].(Object); ok {
+		ranges, rOk := rangeObj["ranges"].([]rangeAggEntry)
+		if !rOk {
+			ranges = make([]rangeAggEntry, 0, 1)
+		}
+		rangeObj["ranges"] = append(ranges, entry)
+	}
+	return r
+}
+
+// Keyed sets the "keyed" parameter in the range aggregation.
+//
+// This method specifies whether the buckets should be returned as a hash instead of an array.
+// When set to true, each bucket is associated with a unique string key.
+//
+// Example usage:
+//
+//	agg := es.RangeAgg("price").Keyed(true)
+//
+// Parameters:
+//   - keyed: A boolean indicating whether to return keyed buckets.
+//
+// Returns:
+//
+//	The updated es.rangeAggType object with the "keyed" parameter set.
+func (r rangeAggType) Keyed(keyed bool) rangeAggType {
+	return r.putInTheField("keyed", keyed)
+}
+
+// Missing sets a default value to use for documents that do not contain the field.
+//
+// Example usage:
+//
+//	agg := es.RangeAgg("price").Missing(0)
+//
+// Parameters:
+//   - missing: The value to use when a document lacks the field.
+//
+// Returns:
+//
+//	An es.rangeAggType object with the "missing" field set.
+func (r rangeAggType) Missing(missing any) rangeAggType {
+	return r.putInTheField("missing", missing)
+}
+
+// Aggs adds sub-aggregations to the range aggregation.
+//
+// Example usage:
+//
+//	agg := es.RangeAgg("price").
+//		Range(es.RangeEntry().To(50)).
+//		Aggs(es.Agg("avg_score", es.AvgAgg("score")))
+//
+// Parameters:
+//   - aggs: A variadic list of sub-aggregations.
+//
+// Returns:
+//
+//	An es.rangeAggType object with the specified sub-aggregations added.
+func (r rangeAggType) Aggs(aggs ...aggsType) rangeAggType {
+	return genericPutAggsInRoot(r, aggs)
+}
+
+// Meta adds metadata to the range aggregation.
+//
+// Example usage:
+//
+//	agg := es.RangeAgg("price").Meta("description", "Price ranges")
+//
+// Parameters:
+//   - key: Metadata key.
+//   - value: Metadata value.
+//
+// Returns:
+//
+//	A modified es.rangeAggType with the meta field set.
+func (r rangeAggType) Meta(key string, value any) rangeAggType {
+	meta, ok := r["meta"].(Object)
+	if !ok {
+		meta = Object{}
+	}
+	meta[key] = value
+	r["meta"] = meta
+	return r
+}
+
+func (r rangeAggType) putInTheField(key string, value any) rangeAggType {
+	return genericPutInTheField(r, "range", key, value)
+}
+
+// RangeEntry creates a new range entry for use in a range aggregation.
+//
+// Example usage:
+//
+//	entry := es.RangeEntry().From(10).To(50)
+//
+// Returns:
+//
+//	An es.rangeAggEntry object ready for configuration.
+func RangeEntry() rangeAggEntry {
+	return rangeAggEntry{}
+}
+
+// From sets the "from" boundary of the range entry (inclusive).
+//
+// Example usage:
+//
+//	entry := es.RangeEntry().From(50)
+//
+// Parameters:
+//   - from: The lower boundary of the range.
+//
+// Returns:
+//
+//	The updated es.rangeAggEntry object with the "from" boundary set.
+func (e rangeAggEntry) From(from any) rangeAggEntry {
+	e["from"] = from
+	return e
+}
+
+// To sets the "to" boundary of the range entry (exclusive).
+//
+// Example usage:
+//
+//	entry := es.RangeEntry().To(100)
+//
+// Parameters:
+//   - to: The upper boundary of the range.
+//
+// Returns:
+//
+//	The updated es.rangeAggEntry object with the "to" boundary set.
+func (e rangeAggEntry) To(to any) rangeAggEntry {
+	e["to"] = to
+	return e
+}
+
+// Key sets a custom key for the range entry bucket.
+//
+// Example usage:
+//
+//	entry := es.RangeEntry().Key("cheap").To(50)
+//
+// Parameters:
+//   - key: A string representing the custom bucket key.
+//
+// Returns:
+//
+//	The updated es.rangeAggEntry object with the "key" set.
+func (e rangeAggEntry) Key(key string) rangeAggEntry {
+	e["key"] = key
+	return e
+}

--- a/es/aggregation_range_test.go
+++ b/es/aggregation_range_test.go
@@ -1,0 +1,227 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   RangeAgg   ////
+
+func Test_RangeAgg_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.RangeAgg)
+}
+
+func Test_RangeAgg_method_should_create_rangeAggType(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price")
+
+	// Then
+	assert.NotNil(t, agg)
+	assert.IsTypeString(t, "es.rangeAggType", agg)
+}
+
+func Test_RangeAgg_should_create_json_with_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"range\":{\"field\":\"price\"}}", bodyJSON)
+}
+
+////   RangeAgg Range   ////
+
+func Test_RangeAgg_should_have_Range_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price")
+
+	// When Then
+	assert.NotNil(t, agg.Range)
+}
+
+func Test_RangeAgg_Range_should_create_json_with_ranges(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("price_ranges",
+			es.RangeAgg("price").
+				Range(es.RangeEntry().To(50)).
+				Range(es.RangeEntry().From(50).To(100)).
+				Range(es.RangeEntry().From(100)),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"price_ranges\":{\"range\":{\"field\":\"price\",\"ranges\":[{\"to\":50},{\"from\":50,\"to\":100},{\"from\":100}]}}},\"query\":{}}", bodyJSON)
+}
+
+func Test_RangeAgg_Range_should_create_json_with_keyed_ranges(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price").
+		Range(es.RangeEntry().Key("cheap").To(50)).
+		Range(es.RangeEntry().Key("average").From(50).To(100)).
+		Range(es.RangeEntry().Key("expensive").From(100))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"range\":{\"field\":\"price\",\"ranges\":[{\"key\":\"cheap\",\"to\":50},{\"from\":50,\"key\":\"average\",\"to\":100},{\"from\":100,\"key\":\"expensive\"}]}}", bodyJSON)
+}
+
+////   RangeAgg Keyed   ////
+
+func Test_RangeAgg_should_have_Keyed_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price")
+
+	// When Then
+	assert.NotNil(t, agg.Keyed)
+}
+
+func Test_RangeAgg_Keyed_should_create_json_with_keyed_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price").Keyed(true)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"range\":{\"field\":\"price\",\"keyed\":true}}", bodyJSON)
+}
+
+////   RangeAgg Missing   ////
+
+func Test_RangeAgg_should_have_Missing_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price")
+
+	// When Then
+	assert.NotNil(t, agg.Missing)
+}
+
+func Test_RangeAgg_Missing_should_create_json_with_missing_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price").Missing(0)
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"range\":{\"field\":\"price\",\"missing\":0}}", bodyJSON)
+}
+
+////   RangeAgg Aggs   ////
+
+func Test_RangeAgg_should_have_Aggs_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price")
+
+	// When Then
+	assert.NotNil(t, agg.Aggs)
+}
+
+func Test_RangeAgg_Aggs_should_create_json_with_sub_aggregations(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("price_ranges",
+			es.RangeAgg("price").
+				Range(es.RangeEntry().To(50)).
+				Range(es.RangeEntry().From(50)).
+				Aggs(es.Agg("avg_score", es.AvgAgg("score"))),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"price_ranges\":{\"aggs\":{\"avg_score\":{\"avg\":{\"field\":\"score\"}}},\"range\":{\"field\":\"price\",\"ranges\":[{\"to\":50},{\"from\":50}]}}},\"query\":{}}", bodyJSON)
+}
+
+////   RangeAgg Meta   ////
+
+func Test_RangeAgg_should_have_Meta_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price")
+
+	// When Then
+	assert.NotNil(t, agg.Meta)
+}
+
+func Test_RangeAgg_Meta_should_create_json_with_meta_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.RangeAgg("price").Meta("color", "blue")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"meta\":{\"color\":\"blue\"},\"range\":{\"field\":\"price\"}}", bodyJSON)
+}
+
+////   RangeEntry   ////
+
+func Test_RangeEntry_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.RangeEntry)
+}
+
+func Test_RangeEntry_method_should_create_rangeAggEntry(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.RangeEntry()
+
+	// Then
+	assert.NotNil(t, entry)
+	assert.IsTypeString(t, "es.rangeAggEntry", entry)
+}
+
+func Test_RangeEntry_From_should_create_json_with_from_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.RangeEntry().From(50)
+
+	// When Then
+	assert.NotNil(t, entry)
+	bodyJSON := assert.MarshalWithoutError(t, entry)
+	assert.Equal(t, "{\"from\":50}", bodyJSON)
+}
+
+func Test_RangeEntry_To_should_create_json_with_to_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.RangeEntry().To(100)
+
+	// When Then
+	assert.NotNil(t, entry)
+	bodyJSON := assert.MarshalWithoutError(t, entry)
+	assert.Equal(t, "{\"to\":100}", bodyJSON)
+}
+
+func Test_RangeEntry_Key_should_create_json_with_key_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	entry := es.RangeEntry().Key("cheap").To(50)
+
+	// When Then
+	assert.NotNil(t, entry)
+	bodyJSON := assert.MarshalWithoutError(t, entry)
+	assert.Equal(t, "{\"key\":\"cheap\",\"to\":50}", bodyJSON)
+}

--- a/es/aggregation_reverse_nested.go
+++ b/es/aggregation_reverse_nested.go
@@ -1,0 +1,94 @@
+package es
+
+type reverseNestedAggType Object
+
+// ReverseNestedAgg creates a reverse nested aggregation.
+//
+// A reverse nested aggregation is a special single bucket aggregation that enables
+// aggregating on parent documents from nested documents. It can only be used inside
+// a nested aggregation. It effectively "joins back" to the root/parent document level.
+//
+// Example usage:
+//
+//	agg := es.NestedAgg("comments").
+//		Aggs(
+//			es.Agg("top_usernames", es.TermsAgg("comments.username")),
+//			es.Agg("comment_to_issue", es.ReverseNestedAgg().
+//				Aggs(es.Agg("top_tags_per_comment", es.TermsAgg("tags")))),
+//		)
+//
+// Returns:
+//
+//	An es.reverseNestedAggType object representing the reverse nested aggregation.
+func ReverseNestedAgg() reverseNestedAggType {
+	return reverseNestedAggType{
+		"reverse_nested": Object{},
+	}
+}
+
+// Path sets the "path" parameter in the reverse nested aggregation.
+//
+// This method defines which nested object field should be joined back to. The default
+// is empty, which means it joins back to the root/parent document level. If a path is
+// specified, it joins back to the specified nested object level.
+//
+// Example usage:
+//
+//	agg := es.ReverseNestedAgg().Path("comments")
+//
+// Parameters:
+//   - path: A string representing the nested object path to join back to.
+//
+// Returns:
+//
+//	The updated es.reverseNestedAggType object with the "path" parameter set.
+func (rn reverseNestedAggType) Path(path string) reverseNestedAggType {
+	return rn.putInTheField("path", path)
+}
+
+// Aggs adds sub-aggregations to the reverse nested aggregation.
+//
+// This method allows performing additional aggregations on the parent documents
+// after joining back from the nested context.
+//
+// Example usage:
+//
+//	agg := es.ReverseNestedAgg().
+//		Aggs(es.Agg("top_tags", es.TermsAgg("tags")))
+//
+// Parameters:
+//   - aggs: A variadic list of sub-aggregations.
+//
+// Returns:
+//
+//	An es.reverseNestedAggType object with the specified sub-aggregations added.
+func (rn reverseNestedAggType) Aggs(aggs ...aggsType) reverseNestedAggType {
+	return genericPutAggsInRoot(rn, aggs)
+}
+
+// Meta adds metadata to the reverse nested aggregation.
+//
+// Example usage:
+//
+//	agg := es.ReverseNestedAgg().Meta("description", "Back to parent")
+//
+// Parameters:
+//   - key: Metadata key.
+//   - value: Metadata value.
+//
+// Returns:
+//
+//	A modified es.reverseNestedAggType with the meta field set.
+func (rn reverseNestedAggType) Meta(key string, value any) reverseNestedAggType {
+	meta, ok := rn["meta"].(Object)
+	if !ok {
+		meta = Object{}
+	}
+	meta[key] = value
+	rn["meta"] = meta
+	return rn
+}
+
+func (rn reverseNestedAggType) putInTheField(key string, value any) reverseNestedAggType {
+	return genericPutInTheField(rn, "reverse_nested", key, value)
+}

--- a/es/aggregation_reverse_nested_test.go
+++ b/es/aggregation_reverse_nested_test.go
@@ -1,0 +1,126 @@
+package es_test
+
+import (
+	"testing"
+
+	"github.com/Trendyol/es-query-builder/es"
+	"github.com/Trendyol/es-query-builder/test/assert"
+)
+
+////   ReverseNestedAgg   ////
+
+func Test_ReverseNestedAgg_should_exist_on_es_package(t *testing.T) {
+	t.Parallel()
+	// Given When Then
+	assert.NotNil(t, es.ReverseNestedAgg)
+}
+
+func Test_ReverseNestedAgg_method_should_create_reverseNestedAggType(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg()
+
+	// Then
+	assert.NotNil(t, agg)
+	assert.IsTypeString(t, "es.reverseNestedAggType", agg)
+}
+
+func Test_ReverseNestedAgg_should_create_json_with_reverse_nested(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg()
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"reverse_nested\":{}}", bodyJSON)
+}
+
+////   ReverseNestedAgg Path   ////
+
+func Test_ReverseNestedAgg_should_have_Path_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg()
+
+	// When Then
+	assert.NotNil(t, agg.Path)
+}
+
+func Test_ReverseNestedAgg_Path_should_create_json_with_path_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg().Path("comments")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"reverse_nested\":{\"path\":\"comments\"}}", bodyJSON)
+}
+
+////   ReverseNestedAgg Aggs   ////
+
+func Test_ReverseNestedAgg_should_have_Aggs_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg()
+
+	// When Then
+	assert.NotNil(t, agg.Aggs)
+}
+
+func Test_ReverseNestedAgg_Aggs_should_create_json_with_sub_aggregations(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg().
+		Aggs(es.Agg("top_tags", es.TermsAgg("tags")))
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"aggs\":{\"top_tags\":{\"terms\":{\"field\":\"tags\"}}},\"reverse_nested\":{}}", bodyJSON)
+}
+
+func Test_ReverseNestedAgg_inside_nested_agg_should_create_correct_json(t *testing.T) {
+	t.Parallel()
+	// Given
+	query := es.NewQuery(nil).
+		Aggs(es.Agg("comments",
+			es.NestedAgg("comments").
+				Aggs(
+					es.Agg("top_usernames", es.TermsAgg("comments.username")),
+					es.Agg("comment_to_issue",
+						es.ReverseNestedAgg().
+							Aggs(es.Agg("top_tags_per_comment", es.TermsAgg("tags"))),
+					),
+				),
+		))
+
+	// When Then
+	assert.NotNil(t, query)
+	bodyJSON := assert.MarshalWithoutError(t, query)
+	// nolint:golint,lll
+	assert.Equal(t, "{\"aggs\":{\"comments\":{\"aggs\":{\"comment_to_issue\":{\"aggs\":{\"top_tags_per_comment\":{\"terms\":{\"field\":\"tags\"}}},\"reverse_nested\":{}},\"top_usernames\":{\"terms\":{\"field\":\"comments.username\"}}},\"nested\":{\"path\":\"comments\"}}},\"query\":{}}", bodyJSON)
+}
+
+////   ReverseNestedAgg Meta   ////
+
+func Test_ReverseNestedAgg_should_have_Meta_method(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg()
+
+	// When Then
+	assert.NotNil(t, agg.Meta)
+}
+
+func Test_ReverseNestedAgg_Meta_should_create_json_with_meta_field(t *testing.T) {
+	t.Parallel()
+	// Given
+	agg := es.ReverseNestedAgg().Meta("color", "blue")
+
+	// When Then
+	assert.NotNil(t, agg)
+	bodyJSON := assert.MarshalWithoutError(t, agg)
+	assert.Equal(t, "{\"meta\":{\"color\":\"blue\"},\"reverse_nested\":{}}", bodyJSON)
+}


### PR DESCRIPTION
Implement the following bucket aggregations with full DSL support:

- FilterAgg: Single filter bucket aggregation with Aggs, Meta
- FiltersAgg: Named multi-bucket filter aggregation with Filter, OtherBucket, OtherBucketKey, Aggs, Meta
- RangeAgg: Numeric range bucket aggregation with Range, Keyed, Missing, Aggs, Meta + RangeEntry (From, To, Key)
- DateRangeAgg: Date range bucket aggregation with Range, Format, Keyed, Missing, TimeZone, Aggs, Meta + DateRangeEntry (From, To, Key)
- HistogramAgg: Fixed-interval numeric histogram with MinDocCount, ExtendedBounds, HardBounds, Offset, Keyed, Missing, Order, Aggs, Meta
- DateHistogramAgg: Date-based histogram with CalendarInterval, FixedInterval, Format, TimeZone, Offset, MinDocCount, ExtendedBounds, HardBounds, Keyed, Missing, Order, Aggs, Meta
- ReverseNestedAgg: Reverse nested aggregation with Path, Aggs, Meta

All implementations follow existing project conventions and patterns.